### PR TITLE
Fix renderWithQueryClient for testing

### DIFF
--- a/lingetic-nextjs-frontend/utilities/testing-helpers.tsx
+++ b/lingetic-nextjs-frontend/utilities/testing-helpers.tsx
@@ -1,9 +1,15 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render } from "@testing-library/react";
 
-const queryClient = new QueryClient();
-
 export const renderWithQueryClient = (component: React.ReactElement) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
   return render(
     <QueryClientProvider client={queryClient}>{component}</QueryClientProvider>
   );


### PR DESCRIPTION
For testing, retries should be disabled since they can cause tests
to timeout. Moreover, since the React Query client stores state, a
new query client should be created for each call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated testing configuration to disable automatic query retries during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->