### PR TITLE
Make tests less dependent on question text

### DIFF
--- a/lingetic-nextjs-frontend/__tests__/components/challenges/FillInTheBlanks/FillInTheBlanks.test.tsx
+++ b/lingetic-nextjs-frontend/__tests__/components/challenges/FillInTheBlanks/FillInTheBlanks.test.tsx
@@ -24,9 +24,7 @@ describe("FillInTheBlanks", () => {
 
   it("renders the question and hint", () => {
     renderWithQueryClient(<FillInTheBlanks question={mockQuestion} />);
-    expect(
-      screen.getByText(new RegExp(escapeRegex(mockQuestion.text)))
-    ).toBeInTheDocument();
+    expect(screen.getByText(/the cat/i)).toBeInTheDocument();
     expect(
       screen.getByText(new RegExp(escapeRegex(mockQuestion.hint)))
     ).toBeInTheDocument();

--- a/lingetic-nextjs-frontend/__tests__/pages/learn/LearnPage.test.tsx
+++ b/lingetic-nextjs-frontend/__tests__/pages/learn/LearnPage.test.tsx
@@ -101,7 +101,7 @@ describe("LearnPage", () => {
     renderWithQueryClient(<LearnPage />);
 
     await waitFor(() => {
-      expect(screen.getByText(/The cat ____ lazily/i)).toBeInTheDocument();
+      expect(screen.getByText(/the cat/i)).toBeInTheDocument();
     });
   });
 
@@ -115,7 +115,7 @@ describe("LearnPage", () => {
     });
 
     fireEvent.click(screen.getByText(/next/i));
-    expect(screen.getByText(/She ____ her coffee/i)).toBeInTheDocument();
+    expect(screen.getByText(/her coffee/i)).toBeInTheDocument();
   });
 
   it("advances to the next question when Next button is clicked", async () => {
@@ -124,12 +124,12 @@ describe("LearnPage", () => {
     renderWithQueryClient(<LearnPage />);
 
     await waitFor(() => {
-      expect(screen.getByText(/The cat ____ lazily/i)).toBeInTheDocument();
+      expect(screen.getByText(/the cat/i)).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByText(/next/i));
 
-    expect(screen.getByText(/She ____ her coffee/i)).toBeInTheDocument();
+    expect(screen.getByText(/her coffee/i)).toBeInTheDocument();
   });
 
   it("shows a finish button on the last question", async () => {


### PR DESCRIPTION
Question text may be rendered in many different ways. So, tests
should only test small portions of the question text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Updated test assertions in `FillInTheBlanks` and `LearnPage` components.
	- Simplified text matching in test cases to check for more general forms of text.
	- Maintained overall test coverage and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->