### PR TITLE
Handle case when API returns no questions

### DIFF
--- a/lingetic-nextjs-frontend/__tests__/pages/learn/LearnPage.test.tsx
+++ b/lingetic-nextjs-frontend/__tests__/pages/learn/LearnPage.test.tsx
@@ -170,4 +170,19 @@ describe("LearnPage", () => {
 
     expect(mockPush).toHaveBeenCalled();
   });
+
+  it("shows a message when no questions are available", async () => {
+    (global.fetch as jest.Mock).mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      })
+    );
+
+    renderWithQueryClient(<LearnPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/no questions available/i)).toBeInTheDocument();
+    });
+  });
 });

--- a/lingetic-nextjs-frontend/app/languages/learn/[language]/page.tsx
+++ b/lingetic-nextjs-frontend/app/languages/learn/[language]/page.tsx
@@ -36,6 +36,16 @@ export default function LearnPage() {
     );
   }
 
+  if (!result.hasQuestions) {
+    return (
+      <div className="container mx-auto p-4">
+        <p className="text-skin-base">
+          No questions available for this language.
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div className="container mx-auto p-4">
       <h1 className="text-skin-base text-3xl font-bold mb-6">

--- a/lingetic-nextjs-frontend/app/languages/learn/[language]/useQuestions.ts
+++ b/lingetic-nextjs-frontend/app/languages/learn/[language]/useQuestions.ts
@@ -16,22 +16,35 @@ interface UseQuestionsParams {
 interface LoadingState {
   isLoading: true;
   isError: false;
+  hasQuestions: false;
 }
 
 interface ErrorState {
   isLoading: false;
   isError: true;
+  hasQuestions: false;
+}
+
+interface NoQuestionsState {
+  isLoading: false;
+  isError: false;
+  hasQuestions: false;
 }
 
 interface SuccessState {
   isLoading: false;
   isError: false;
+  hasQuestions: true;
   currentQuestion: Question;
   isLastQuestion: boolean;
   onNext: () => void;
 }
 
-type UseQuestionsResult = LoadingState | ErrorState | SuccessState;
+type UseQuestionsResult =
+  | LoadingState
+  | ErrorState
+  | NoQuestionsState
+  | SuccessState;
 
 export default function useQuestions({
   onFinish,
@@ -62,6 +75,7 @@ export default function useQuestions({
     return {
       isLoading: true,
       isError: false,
+      hasQuestions: false,
     };
   }
 
@@ -69,6 +83,15 @@ export default function useQuestions({
     return {
       isLoading: false,
       isError: true,
+      hasQuestions: false,
+    };
+  }
+
+  if (questions.length === 0) {
+    return {
+      isLoading: false,
+      isError: false,
+      hasQuestions: false,
     };
   }
 
@@ -83,6 +106,7 @@ export default function useQuestions({
   return {
     isLoading: false,
     isError: false,
+    hasQuestions: true,
     currentQuestion: questions[currentQuestionIndex],
     isLastQuestion: currentQuestionIndex === questions.length - 1,
     onNext,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added handling for scenarios with no available questions in the Learn page, displaying a message when no questions are present.
	- Enhanced state management in the question retrieval hook to explicitly handle empty question sets.

- **Tests**
	- Added test case to verify behavior when no questions are available.

The changes improve the user experience by providing clear feedback when no learning questions are present for a selected language.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->