### PR TITLE
Avoid race condition when submitting answer

### DIFF
--- a/lingetic-nextjs-frontend/app/components/challenges/FillInTheBlanks/useUserAnswer.ts
+++ b/lingetic-nextjs-frontend/app/components/challenges/FillInTheBlanks/useUserAnswer.ts
@@ -43,6 +43,10 @@ export default function useUserAnswer(questionId: string) {
   }, [questionId]);
 
   const checkAnswer = async () => {
+    if (attempChallengeMutation.isPending) {
+      return;
+    }
+
     try {
       await attempChallengeMutation.mutateAsync(answer);
     } catch (error) {


### PR DESCRIPTION
In the older code, had the user clicked the check button multiple
times, multiple requests would have gone to the server. The
response from the server could have been in any order. Thus, the
ultimate response from the mutation could be different from the
response that would have been expected from the last sent request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of concurrent challenge attempts by preventing multiple simultaneous mutation requests.
	- Enhanced mutation request management to avoid potential race conditions during challenge submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->