### PR TITLE
Exit if assertion fails

### DIFF
--- a/lingetic-nextjs-frontend/app/error.tsx
+++ b/lingetic-nextjs-frontend/app/error.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import Link from "next/link";
+
+interface ErrorPageProps {
+  error: Error;
+}
+
+export default function ErrorPage({ error }: ErrorPageProps) {
+  const handleReload = () => {
+    window.location.reload();
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+      <div className="max-w-md w-full space-y-8 p-10 bg-white shadow rounded-xl">
+        <div className="text-center">
+          <h1 className="text-3xl font-bold text-[#374151] mb-2">
+            Oops! Something went wrong.
+          </h1>
+          <p className="text-[#dc2626] mb-8">
+            We encountered an unexpected error.
+            {process.env.NODE_ENV === "development" && (
+              <span className="block mt-2 text-sm">{error.message}</span>
+            )}
+          </p>
+        </div>
+        <div className="flex flex-col space-y-4">
+          <button
+            autoFocus
+            type="button"
+            onClick={handleReload}
+            className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-[#ffffff] bg-[#2563eb] hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+          >
+            Reload page
+          </button>
+          <Link
+            href="/"
+            className="w-full flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-[#374151] bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+          >
+            Return to homepage
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lingetic-nextjs-frontend/utilities/assert.ts
+++ b/lingetic-nextjs-frontend/utilities/assert.ts
@@ -1,10 +1,13 @@
-import log from './logger';
+import log from "./logger";
 
-export default function assert(isAssertionTrue: boolean, assertionDescription: string) {
+export default function assert(
+  isAssertionTrue: boolean,
+  assertionDescription: string
+) {
   if (isAssertionTrue) {
     return;
   }
 
-
-  log(assertionDescription, 'fatal');
+  log(assertionDescription, "fatal");
+  throw new Error("Assertion failed.");
 }


### PR DESCRIPTION
Next.js automatically restarts on process.exit. Exiting allows
the process to restart, and prevents continuining with a bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a user-friendly error handling component, `ErrorPage`, with a reload button for unexpected errors.

- **Bug Fixes**
	- Improved error handling for assertions by terminating the process when an assertion fails.

- **Chores**
	- Updated import statement formatting and function signature for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->