### PR TITLE
Don't generate XML coverage report

### DIFF
--- a/lingetic-spring-backend/build.gradle.kts
+++ b/lingetic-spring-backend/build.gradle.kts
@@ -33,7 +33,6 @@ tasks.withType<Test> {
 tasks.jacocoTestReport {
 	dependsOn(tasks.test)
 	reports {
-		xml.required.set(true)
 		html.required.set(true)
 	}
 }


### PR DESCRIPTION
The XML coverage report is not used. Only the HTML one is used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated build configuration for test coverage reporting
	- Removed XML report generation requirement for Jacoco test coverage tool

<!-- end of auto-generated comment: release notes by coderabbit.ai -->