### PR TITLE
Implement the attempt question use case

### DIFF
--- a/lingetic-nextjs-frontend/__tests__/components/challenges/FillInTheBlanks/FillInTheBlanks.test.tsx
+++ b/lingetic-nextjs-frontend/__tests__/components/challenges/FillInTheBlanks/FillInTheBlanks.test.tsx
@@ -41,7 +41,7 @@ describe("FillInTheBlanks", () => {
   it("submits the answer when Enter key is pressed", async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       ok: true,
-      json: () => Promise.resolve({ status: "success", comment: "Great job!" }),
+      json: () => Promise.resolve({ status: "Success", comment: "Great job!" }),
     });
 
     renderWithQueryClient(<FillInTheBlanks question={mockQuestion} />);
@@ -58,7 +58,7 @@ describe("FillInTheBlanks", () => {
   it("submits the answer and shows correct feedback", async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       ok: true,
-      json: () => Promise.resolve({ status: "success", comment: "Great job!" }),
+      json: () => Promise.resolve({ status: "Success", comment: "Great job!" }),
     });
 
     renderWithQueryClient(<FillInTheBlanks question={mockQuestion} />);
@@ -77,7 +77,7 @@ describe("FillInTheBlanks", () => {
       ok: true,
       json: () =>
         Promise.resolve({
-          status: "failure",
+          status: "Failure",
           comment: "Try again.",
           answer: "stretched",
         }),
@@ -98,7 +98,7 @@ describe("FillInTheBlanks", () => {
   it("submits the answer and does not show undefined feedback when there is no feedback", async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       ok: true,
-      json: () => Promise.resolve({ status: "failure" }),
+      json: () => Promise.resolve({ status: "Failure" }),
     });
 
     renderWithQueryClient(<FillInTheBlanks question={mockQuestion} />);
@@ -115,7 +115,7 @@ describe("FillInTheBlanks", () => {
   it("submits the answer and does not show feedback when feedback is null", async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       ok: true,
-      json: () => Promise.resolve({ status: "failure", comment: null }),
+      json: () => Promise.resolve({ status: "Failure", comment: null }),
     });
 
     renderWithQueryClient(<FillInTheBlanks question={mockQuestion} />);
@@ -132,7 +132,7 @@ describe("FillInTheBlanks", () => {
   it("submits the answer and does not show feedback when feedback is blank", async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       ok: true,
-      json: () => Promise.resolve({ status: "failure", comment: "\t\n   " }),
+      json: () => Promise.resolve({ status: "Failure", comment: "\t\n   " }),
     });
 
     renderWithQueryClient(<FillInTheBlanks question={mockQuestion} />);
@@ -149,7 +149,7 @@ describe("FillInTheBlanks", () => {
   it("does not allow checking twice", async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       ok: true,
-      json: () => Promise.resolve({ status: "success" }),
+      json: () => Promise.resolve({ status: "Success" }),
     });
 
     renderWithQueryClient(<FillInTheBlanks question={mockQuestion} />);
@@ -231,7 +231,7 @@ describe("FillInTheBlanks", () => {
     it("should make the check button visible again", async () => {
       (global.fetch as jest.Mock).mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve({ status: "success" }),
+        json: () => Promise.resolve({ status: "Success" }),
       });
 
       renderWithQueryClient(<TestComponent />);
@@ -251,7 +251,7 @@ describe("FillInTheBlanks", () => {
       (global.fetch as jest.Mock).mockResolvedValueOnce({
         ok: true,
         json: () =>
-          Promise.resolve({ status: "success", comment: "Great job!" }),
+          Promise.resolve({ status: "Success", comment: "Great job!" }),
       });
 
       renderWithQueryClient(<TestComponent />);

--- a/lingetic-nextjs-frontend/app/components/challenges/FillInTheBlanks/FillInTheBlanks.tsx
+++ b/lingetic-nextjs-frontend/app/components/challenges/FillInTheBlanks/FillInTheBlanks.tsx
@@ -86,15 +86,15 @@ export default function FillInTheBlanks({
         <div>
           <p
             className={`mb-4 ${
-              result.status === "success"
+              result.status === "Success"
                 ? "text-skin-success"
                 : "text-skin-error"
             }`}
           >
-            {result.status === "success" ? "Correct!" : "Incorrect."}
+            {result.status === "Success" ? "Correct!" : "Incorrect."}
             {result.comment && ` ${result.comment}`}
           </p>
-          {result.status === "failure" && result.answer && (
+          {result.status === "Failure" && result.answer && (
             <p>Correct answer: {result.answer}</p>
           )}
         </div>

--- a/lingetic-nextjs-frontend/utilities/api.ts
+++ b/lingetic-nextjs-frontend/utilities/api.ts
@@ -31,7 +31,7 @@ export async function fetchQuestions(language: string): Promise<Question[]> {
 }
 
 export type AttemptResponse = {
-  status: "success" | "failure";
+  status: "Success" | "Failure";
   comment?: string;
   answer?: string;
 };

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptResponse.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptResponse.java
@@ -1,4 +1,6 @@
 package com.munetmo.lingetic.LanguageTestService.DTOs.Attempt;
 
-public record AttemptResponse(String status, String comment, String answer) {
+import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
+
+public record AttemptResponse(AttemptStatus status, String comment, String answer) {
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Assessments/Assessment.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Assessments/Assessment.java
@@ -1,0 +1,11 @@
+package com.munetmo.lingetic.LanguageTestService.Entities.Assessments;
+
+import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponse;
+import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
+
+public sealed interface Assessment permits FillInTheBlanksAssessment {
+    public String getType();
+    public AttemptStatus getStatus();
+    public String getComment();
+    public AttemptResponse toDTO();
+}

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Assessments/FillInTheBlanksAssessment.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Assessments/FillInTheBlanksAssessment.java
@@ -1,0 +1,37 @@
+package com.munetmo.lingetic.LanguageTestService.Entities.Assessments;
+
+import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponse;
+import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
+
+public final class FillInTheBlanksAssessment implements Assessment {
+    private final static String type = "FillInTheBlanks";
+    private final AttemptStatus status;
+    private final String comment;
+    public final String answer;
+
+    public FillInTheBlanksAssessment(AttemptStatus status, String comment, String answer) {
+        this.status = status;
+        this.comment = comment;
+        this.answer = answer;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public AttemptStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getComment() {
+        return comment;
+    }
+
+    @Override
+    public AttemptResponse toDTO() {
+        return new AttemptResponse(getStatus(), getComment(), answer);
+    }
+}

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/AttemptStatus.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/AttemptStatus.java
@@ -1,0 +1,5 @@
+package com.munetmo.lingetic.LanguageTestService.Entities;
+
+public enum AttemptStatus {
+    Success, Failure
+}

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestion.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestion.java
@@ -1,6 +1,10 @@
 package com.munetmo.lingetic.LanguageTestService.Entities.Questions;
 
 import com.munetmo.lingetic.LanguageTestService.DTOs.Question.FillInTheBlanksQuestionDTO;
+import com.munetmo.lingetic.LanguageTestService.Entities.Assessments.FillInTheBlanksAssessment;
+import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
+import com.munetmo.lingetic.LanguageTestService.Entities.UserResponses.FillInTheBlanksUserResponse;
+import com.munetmo.lingetic.LanguageTestService.Entities.UserResponses.UserResponse;
 
 public final class FillInTheBlanksQuestion implements Question {
     private final String id;
@@ -30,5 +34,16 @@ public final class FillInTheBlanksQuestion implements Question {
     @Override
     public FillInTheBlanksQuestionDTO toDTO() {
         return new FillInTheBlanksQuestionDTO(getID(), questionText, hint);
+    }
+
+    @Override
+    public FillInTheBlanksAssessment assess(UserResponse userResponse) {
+        assert(userResponse.getType().equals(getType()));
+
+        var typedUserResponse = (FillInTheBlanksUserResponse)userResponse;
+        if (typedUserResponse.getAnswer().equals(answer)) {
+            return new FillInTheBlanksAssessment(AttemptStatus.Success, "Good job!", answer);
+        }
+        return new FillInTheBlanksAssessment(AttemptStatus.Failure, "Try again!", answer);
     }
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/Question.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/Question.java
@@ -1,9 +1,12 @@
 package com.munetmo.lingetic.LanguageTestService.Entities.Questions;
 
 import com.munetmo.lingetic.LanguageTestService.DTOs.Question.QuestionDTO;
+import com.munetmo.lingetic.LanguageTestService.Entities.Assessments.Assessment;
+import com.munetmo.lingetic.LanguageTestService.Entities.UserResponses.UserResponse;
 
 public sealed interface Question permits FillInTheBlanksQuestion {
     public String getID();
     public String getType();
     public QuestionDTO toDTO();
+    public Assessment assess(UserResponse userResponse);
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/UserResponses/FillInTheBlanksUserResponse.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/UserResponses/FillInTheBlanksUserResponse.java
@@ -1,0 +1,19 @@
+package com.munetmo.lingetic.LanguageTestService.Entities.UserResponses;
+
+public final class FillInTheBlanksUserResponse implements UserResponse {
+    private static final String type = "FillInTheBlanks";
+    private final String answer;
+
+    public FillInTheBlanksUserResponse(String answer) {
+        this.answer = answer;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    public String getAnswer() {
+        return answer;
+    }
+}

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/UserResponses/UserResponse.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/UserResponses/UserResponse.java
@@ -1,0 +1,5 @@
+package com.munetmo.lingetic.LanguageTestService.Entities.UserResponses;
+
+public sealed interface UserResponse permits FillInTheBlanksUserResponse {
+    public String getType();
+}

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCase.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCase.java
@@ -1,9 +1,25 @@
 package com.munetmo.lingetic.LanguageTestService.UseCases;
 
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.*;
+import com.munetmo.lingetic.LanguageTestService.Entities.UserResponses.FillInTheBlanksUserResponse;
+import com.munetmo.lingetic.LanguageTestService.Repositories.QuestionRepository;
+import org.apache.coyote.http11.filters.IdentityInputFilter;
 
 public class AttemptQuestionUseCase {
-    public AttemptResponse execute(AttemptRequest request) {
-        return new AttemptResponse("success", "Great job!", null);
+    private QuestionRepository questionRepository;
+
+    public AttemptQuestionUseCase(QuestionRepository questionRepository) {
+        this.questionRepository = questionRepository;
+    }
+
+    public AttemptResponse execute(AttemptRequest request) throws Exception {
+        var question = questionRepository.getQuestionByID(request.questionID());
+        var userResponse = switch (question.getType()) {
+            case "FillInTheBlanks" -> new FillInTheBlanksUserResponse(request.userResponse());
+            default -> throw new Exception("Unsupported question type.");
+        };
+
+        var assessment = question.assess(userResponse);
+        return assessment.toDTO();
     }
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/Beans.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/Beans.java
@@ -20,7 +20,7 @@ public class Beans {
     }
 
     @Bean
-    public AttemptQuestionUseCase attemptQuestionUseCase() {
-        return new AttemptQuestionUseCase();
+    public AttemptQuestionUseCase attemptQuestionUseCase(QuestionRepository questionRepository) {
+        return new AttemptQuestionUseCase(questionRepository);
     }
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/HTTP/QuestionsController.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/HTTP/QuestionsController.java
@@ -29,7 +29,7 @@ public class QuestionsController {
     }
 
     @PostMapping("/attempt")
-    public ResponseEntity<AttemptResponse> attemptQuestion(@RequestBody AttemptRequest request) {
+    public ResponseEntity<AttemptResponse> attemptQuestion(@RequestBody AttemptRequest request) throws Exception {
         var response = attemptQuestionUseCase.execute(request);
         return ResponseEntity.ok(response);
     }

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptResponseTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptResponseTest.java
@@ -1,5 +1,6 @@
 package com.munetmo.lingetic.LanguageTestService.DTOs.Attempt;
 
+import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -7,8 +8,8 @@ public class AttemptResponseTest {
 
     @Test
     void shouldCreateAttemptResponse() {
-        AttemptResponse response = new AttemptResponse("correct", "Good job!", "answer");
-        assertEquals("correct", response.status());
+        AttemptResponse response = new AttemptResponse(AttemptStatus.Success, "Good job!", "answer");
+        assertEquals(AttemptStatus.Success, response.status());
         assertEquals("Good job!", response.comment());
         assertEquals("answer", response.answer());
     }


### PR DESCRIPTION
- Make attempt status an enum
- Use polymorphism to check and return assessments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a more robust status handling for fill-in-the-blank challenge responses using an enumeration
	- Added type-safe assessment mechanisms for language learning challenges

- **Refactor**
	- Updated status representation from string to enum across frontend and backend
	- Improved error handling and response validation for challenge attempts

- **Bug Fixes**
	- Standardized status values from lowercase to capitalized format
	- Enhanced type safety in response processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->