### PR TITLE
Use enum to denote Question type instead of string

### DIFF
--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/FillInTheBlanksQuestionDTO.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/FillInTheBlanksQuestionDTO.java
@@ -1,9 +1,10 @@
 package com.munetmo.lingetic.LanguageTestService.DTOs.Question;
 
+import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
 import java.util.Objects;
 
 public final class FillInTheBlanksQuestionDTO implements QuestionDTO {
-    public static final String type = "FillInTheBlanks";
+    public static final QuestionType type = QuestionType.FillInTheBlanks;
     public final String id;
     public final String text;
     public final String hint;
@@ -30,7 +31,8 @@ public final class FillInTheBlanksQuestionDTO implements QuestionDTO {
         return id;
     }
 
-    public String getType() {
+    @Override
+    public QuestionType getType() {
         return type;
     }
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/QuestionDTO.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/QuestionDTO.java
@@ -1,7 +1,9 @@
 package com.munetmo.lingetic.LanguageTestService.DTOs.Question;
 
+import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
+
 public sealed interface QuestionDTO permits FillInTheBlanksQuestionDTO {
     public String getID();
 
-    public String getType();
+    public QuestionType getType();
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Assessments/Assessment.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Assessments/Assessment.java
@@ -2,9 +2,10 @@ package com.munetmo.lingetic.LanguageTestService.Entities.Assessments;
 
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponse;
 import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
+import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
 
 public sealed interface Assessment permits FillInTheBlanksAssessment {
-    public String getType();
+    public QuestionType getType();
     public AttemptStatus getStatus();
     public String getComment();
     public AttemptResponse toDTO();

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Assessments/FillInTheBlanksAssessment.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Assessments/FillInTheBlanksAssessment.java
@@ -2,9 +2,10 @@ package com.munetmo.lingetic.LanguageTestService.Entities.Assessments;
 
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponse;
 import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
+import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
 
 public final class FillInTheBlanksAssessment implements Assessment {
-    private final static String type = "FillInTheBlanks";
+    private final static QuestionType type = QuestionType.FillInTheBlanks;
     private final AttemptStatus status;
     private final String comment;
     public final String answer;
@@ -16,7 +17,7 @@ public final class FillInTheBlanksAssessment implements Assessment {
     }
 
     @Override
-    public String getType() {
+    public QuestionType getType() {
         return type;
     }
 

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestion.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestion.java
@@ -8,7 +8,7 @@ import com.munetmo.lingetic.LanguageTestService.Entities.UserResponses.UserRespo
 
 public final class FillInTheBlanksQuestion implements Question {
     private final String id;
-    private final static String type = "FillInTheBlanks";
+    private final static QuestionType type = QuestionType.FillInTheBlanks;
 
     public final String questionText;
     public final String hint;
@@ -27,7 +27,7 @@ public final class FillInTheBlanksQuestion implements Question {
     }
 
     @Override
-    public String getType() {
+    public QuestionType getType() {
         return type;
     }
 

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/Question.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/Question.java
@@ -6,7 +6,7 @@ import com.munetmo.lingetic.LanguageTestService.Entities.UserResponses.UserRespo
 
 public sealed interface Question permits FillInTheBlanksQuestion {
     public String getID();
-    public String getType();
+    public QuestionType getType();
     public QuestionDTO toDTO();
     public Assessment assess(UserResponse userResponse);
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/QuestionType.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/QuestionType.java
@@ -1,0 +1,5 @@
+package com.munetmo.lingetic.LanguageTestService.Entities.Questions;
+
+public enum QuestionType {
+    FillInTheBlanks
+}

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/UserResponses/FillInTheBlanksUserResponse.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/UserResponses/FillInTheBlanksUserResponse.java
@@ -1,7 +1,9 @@
 package com.munetmo.lingetic.LanguageTestService.Entities.UserResponses;
 
+import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
+
 public final class FillInTheBlanksUserResponse implements UserResponse {
-    private static final String type = "FillInTheBlanks";
+    private static final QuestionType type = QuestionType.FillInTheBlanks;
     private final String answer;
 
     public FillInTheBlanksUserResponse(String answer) {
@@ -9,7 +11,7 @@ public final class FillInTheBlanksUserResponse implements UserResponse {
     }
 
     @Override
-    public String getType() {
+    public QuestionType getType() {
         return type;
     }
 

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/UserResponses/UserResponse.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/UserResponses/UserResponse.java
@@ -1,5 +1,7 @@
 package com.munetmo.lingetic.LanguageTestService.Entities.UserResponses;
 
+import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
+
 public sealed interface UserResponse permits FillInTheBlanksUserResponse {
-    public String getType();
+    public QuestionType getType();
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCase.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCase.java
@@ -3,7 +3,6 @@ package com.munetmo.lingetic.LanguageTestService.UseCases;
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.*;
 import com.munetmo.lingetic.LanguageTestService.Entities.UserResponses.FillInTheBlanksUserResponse;
 import com.munetmo.lingetic.LanguageTestService.Repositories.QuestionRepository;
-import org.apache.coyote.http11.filters.IdentityInputFilter;
 
 public class AttemptQuestionUseCase {
     private QuestionRepository questionRepository;
@@ -15,7 +14,7 @@ public class AttemptQuestionUseCase {
     public AttemptResponse execute(AttemptRequest request) throws Exception {
         var question = questionRepository.getQuestionByID(request.questionID());
         var userResponse = switch (question.getType()) {
-            case "FillInTheBlanks" -> new FillInTheBlanksUserResponse(request.userResponse());
+            case FillInTheBlanks -> new FillInTheBlanksUserResponse(request.userResponse());
             default -> throw new Exception("Unsupported question type.");
         };
 

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/FillInTheBlanksQuestionDTOTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/FillInTheBlanksQuestionDTOTest.java
@@ -1,5 +1,6 @@
 package com.munetmo.lingetic.LanguageTestService.DTOs.Question;
 
+import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -13,7 +14,7 @@ public class FillInTheBlanksQuestionDTOTest {
                 "This is a hint");
 
         assertEquals("q123", question.getID());
-        assertEquals("FillInTheBlanks", question.getType());
+        assertEquals(QuestionType.FillInTheBlanks, question.getType());
         assertEquals("Fill in: ___", question.text);
         assertEquals("This is a hint", question.hint);
     }
@@ -54,7 +55,7 @@ public class FillInTheBlanksQuestionDTOTest {
                 null);
 
         assertEquals("q123", question.getID());
-        assertEquals("FillInTheBlanks", question.getType());
+        assertEquals(QuestionType.FillInTheBlanks, question.getType());
         assertEquals("Fill in: ___", question.text);
         assertEquals("", question.hint);
     }
@@ -67,7 +68,7 @@ public class FillInTheBlanksQuestionDTOTest {
                 "");
 
         assertEquals("q123", question.getID());
-        assertEquals("FillInTheBlanks", question.getType());
+        assertEquals(QuestionType.FillInTheBlanks, question.getType());
         assertEquals("Fill in: ___", question.text);
         assertEquals("", question.hint);
     }


### PR DESCRIPTION
The enum is used to denote the type of not only Questions but also
related entities such as Assessment, QuestionDTO, etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a structured representation for question types that enhances overall consistency.
- **Refactor**
  - Revised question, assessment, and response components to improve type safety and reliability.
  - Updated the handling of question type evaluations for a more robust control flow.
- **Tests**
  - Adjusted validations to align with the new question type representation, ensuring accurate behavior.

These improvements streamline the system’s internal handling of question types, aiming to reduce errors and provide a more consistent experience during language assessments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->