### PR TITLE
Refactor React test cases

### DIFF
--- a/lingetic-nextjs-frontend/__tests__/components/questions/FillInTheBlanks/FillInTheBlanks.test.tsx
+++ b/lingetic-nextjs-frontend/__tests__/components/questions/FillInTheBlanks/FillInTheBlanks.test.tsx
@@ -1,4 +1,4 @@
-import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { fireEvent, waitFor } from "@testing-library/react";
 import {
   escapeRegex,
   renderWithQueryClient,
@@ -14,6 +14,158 @@ import type {
 
 global.fetch = jest.fn();
 
+describe("FillInTheBlanks", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the question parts and hint", async () => {
+    const { findByText } = renderWithQueryClient(
+      <FillInTheBlanks question={mockQuestion} />
+    );
+
+    expect(await findByText(/the cat/i)).toBeInTheDocument();
+    expect(await findByText(/on the windowsill./i)).toBeInTheDocument();
+    expect(
+      await findByText(new RegExp(escapeRegex(mockQuestion.hint)))
+    ).toBeInTheDocument();
+  });
+
+  it("allows user to input an answer", async () => {
+    const { findByRole } = renderWithQueryClient(
+      <FillInTheBlanks question={mockQuestion} />
+    );
+
+    const input = await findByRole("textbox");
+    fireEvent.change(input, { target: { value: "stretched" } });
+
+    await waitFor(() => expect(input).toHaveValue("stretched"));
+  });
+
+  it("submits the answer when Enter key is pressed", async () => {
+    mockSuccessfulAttempt();
+    const { findByRole, findByText } = renderWithQueryClient(
+      <FillInTheBlanks question={mockQuestion} />
+    );
+
+    const input = await findByRole("textbox");
+    fireEvent.change(input, { target: { value: "stretched" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    expect(await findByText(/correct/i)).toBeInTheDocument();
+  });
+
+  it("does not allow checking twice", async () => {
+    mockSuccessfulAttempt();
+    const { findByRole, findByText, queryByText } = renderWithQueryClient(
+      <FillInTheBlanks question={mockQuestion} />
+    );
+
+    await checkAnswer("stretched", findByRole, findByText);
+
+    await waitFor(() => {
+      expect(queryByText("Check")).not.toBeInTheDocument();
+    });
+  });
+
+  it("displays an error when the API request fails", async () => {
+    mockServerError();
+    const { findByRole, findByText } = renderWithQueryClient(
+      <FillInTheBlanks question={mockQuestion} />
+    );
+
+    await checkAnswer("stretched", findByRole, findByText);
+
+    expect(await findByText(/error/i)).toBeInTheDocument();
+  });
+
+  it("displays an error when there is a network failure", async () => {
+    mockNetworkError();
+    const { findByText, findByRole } = renderWithQueryClient(
+      <FillInTheBlanks question={mockQuestion} />
+    );
+
+    await checkAnswer("stretched", findByRole, findByText);
+
+    expect(await findByText(/error/i)).toBeInTheDocument();
+  });
+
+  it("automatically focuses the input box on render", async () => {
+    const { findByRole } = renderWithQueryClient(
+      <FillInTheBlanks question={mockQuestion} />
+    );
+
+    const input = await findByRole("textbox");
+
+    await waitFor(() => expect(input).toHaveFocus());
+  });
+
+  describe("when question changes", () => {
+    it("should clear the input field", async () => {
+      const { findByRole, findByText } = renderWithQueryClient(
+        <ComponentWithChangeQuestionBtn />
+      );
+
+      const input = await findByRole("textbox");
+      await checkAnswerAndChangeQuestion("stretched", findByRole, findByText);
+
+      await waitFor(() => expect(input).toHaveValue(""));
+    });
+
+    it("should make the check button visible again", async () => {
+      mockSuccessfulAttempt();
+      const { findByRole, findByText } = renderWithQueryClient(
+        <ComponentWithChangeQuestionBtn />
+      );
+
+      await checkAnswerAndChangeQuestion("stretched", findByRole, findByText);
+
+      expect(await findByText("Check")).toBeInTheDocument();
+    });
+
+    it("should clear answer status", async () => {
+      mockSuccessfulAttempt();
+      const { findByRole, findByText, queryByText } = renderWithQueryClient(
+        <ComponentWithChangeQuestionBtn />
+      );
+
+      await checkAnswerAndChangeQuestion("stretched", findByRole, findByText);
+
+      await waitFor(() =>
+        expect(queryByText(/correct/i)).not.toBeInTheDocument()
+      );
+    });
+
+    it("should clear error state", async () => {
+      mockNetworkError();
+      const { findByRole, findByText, queryByText } = renderWithQueryClient(
+        <ComponentWithChangeQuestionBtn />
+      );
+
+      await checkAnswerAndChangeQuestion("stretched", findByRole, findByText);
+
+      await waitFor(() =>
+        expect(queryByText(/error/i)).not.toBeInTheDocument()
+      );
+    });
+
+    it("should focus the input box when question changes", async () => {
+      const { findByRole, findByText } = renderWithQueryClient(
+        <ComponentWithChangeQuestionBtn />
+      );
+
+      const input = await findByRole("textbox");
+      input.blur();
+      const changeQuestionButton = await findByText("Change Question");
+      fireEvent.click(changeQuestionButton);
+
+      await waitFor(async () =>
+        expect(await findByRole("textbox")).toHaveFocus()
+      );
+    });
+  });
+});
+
 const mockQuestion = {
   id: "1",
   questionType: "FillInTheBlanks" as const,
@@ -21,212 +173,62 @@ const mockQuestion = {
   hint: "straighten or extend one's body",
 } as FillInTheBlanksQuestion;
 
-describe("FillInTheBlanks", () => {
-  beforeEach(() => {
-    (global.fetch as jest.Mock).mockClear();
+const mockSuccessfulAttempt = () => {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: true,
+    json: () =>
+      Promise.resolve({
+        attemptStatus: "Success",
+        correctAnswer: "stretched",
+        questionType: "FillInTheBlanks",
+      } as FillInTheBlanksAttemptResponse),
   });
+};
 
-  it("renders the question parts and hint", () => {
-    renderWithQueryClient(<FillInTheBlanks question={mockQuestion} />);
-    expect(screen.getByText(/the cat/i)).toBeInTheDocument();
-    expect(screen.getByText(/on the windowsill./i)).toBeInTheDocument();
-    expect(
-      screen.getByText(new RegExp(escapeRegex(mockQuestion.hint)))
-    ).toBeInTheDocument();
+const mockNetworkError = () => {
+  (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("Network error"));
+};
+
+const mockServerError = () => {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: false,
   });
+};
 
-  it("allows user to input an answer", () => {
-    renderWithQueryClient(<FillInTheBlanks question={mockQuestion} />);
-    const input = screen.getByRole("textbox");
-    fireEvent.change(input, { target: { value: "stretched" } });
-    expect(input).toHaveValue("stretched");
-  });
+const checkAnswer = async (
+  answer: string,
+  findByRole: (role: string) => Promise<HTMLElement>,
+  findByText: (text: string | RegExp) => Promise<HTMLElement>
+) => {
+  const input = await findByRole("textbox");
+  fireEvent.change(input, { target: { value: answer } });
+  const checkButton = await findByText("Check");
+  fireEvent.click(checkButton);
+};
 
-  it("submits the answer when Enter key is pressed", async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          attemptStatus: "Success",
-          correctAnswer: "stretched",
-          questionType: "FillInTheBlanks",
-        } as FillInTheBlanksAttemptResponse),
-    });
+const ComponentWithChangeQuestionBtn = () => {
+  const [currentQuestion, setCurrentQuestion] = useState(mockQuestion);
 
-    renderWithQueryClient(<FillInTheBlanks question={mockQuestion} />);
-    const input = screen.getByRole("textbox");
-    fireEvent.change(input, { target: { value: "stretched" } });
-    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+  return (
+    <>
+      <FillInTheBlanks question={currentQuestion} />
+      <button
+        onClick={() =>
+          setCurrentQuestion({ ...mockQuestion, id: "different-id" })
+        }
+      >
+        Change Question
+      </button>
+    </>
+  );
+};
 
-    await waitFor(() => {
-      expect(screen.getByText(/correct/i)).toBeInTheDocument();
-      expect(screen.queryByText(/Great job!/)).not.toBeInTheDocument();
-    });
-  });
-
-  it("does not allow checking twice", async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          attemptStatus: "Success",
-          correctAnswer: "stretched",
-          questionType: "FillInTheBlanks",
-        } as FillInTheBlanksAttemptResponse),
-    });
-
-    renderWithQueryClient(<FillInTheBlanks question={mockQuestion} />);
-    const input = screen.getByRole("textbox");
-    fireEvent.change(input, { target: { value: "stretched" } });
-
-    const checkButton = screen.getByText("Check");
-    fireEvent.click(checkButton);
-
-    await waitFor(() => {
-      expect(screen.queryByText("Check")).not.toBeInTheDocument();
-    });
-  });
-
-  it("displays an error when the API request fails", async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce({
-      ok: false,
-    });
-
-    renderWithQueryClient(<FillInTheBlanks question={mockQuestion} />);
-    const input = screen.getByRole("textbox");
-    fireEvent.change(input, { target: { value: "stretched" } });
-    fireEvent.click(screen.getByText("Check"));
-
-    await waitFor(() => {
-      expect(screen.getByText(/error/i)).toBeInTheDocument();
-    });
-  });
-
-  it("displays an error when there is a network failure", async () => {
-    (global.fetch as jest.Mock).mockRejectedValueOnce(
-      new Error("Network error")
-    );
-
-    renderWithQueryClient(<FillInTheBlanks question={mockQuestion} />);
-    const input = screen.getByRole("textbox");
-    fireEvent.change(input, { target: { value: "stretched" } });
-    fireEvent.click(screen.getByText("Check"));
-
-    await waitFor(() => {
-      expect(screen.getByText(/error/i)).toBeInTheDocument();
-    });
-  });
-
-  it("automatically focuses the input box on render", () => {
-    renderWithQueryClient(<FillInTheBlanks question={mockQuestion} />);
-    const input = screen.getByRole("textbox");
-    expect(input).toHaveFocus();
-  });
-
-  describe("when question changes", () => {
-    const TestComponent = () => {
-      const [currentQuestion, setCurrentQuestion] = useState(mockQuestion);
-
-      return (
-        <>
-          <FillInTheBlanks question={currentQuestion} />
-          <button
-            onClick={() =>
-              setCurrentQuestion({ ...mockQuestion, id: "different-id" })
-            }
-          >
-            Change Question
-          </button>
-        </>
-      );
-    };
-
-    it("should clear the input field", () => {
-      renderWithQueryClient(<TestComponent />);
-      const input = screen.getByRole("textbox");
-      fireEvent.change(input, { target: { value: "test answer" } });
-      expect(input).toHaveValue("test answer");
-
-      fireEvent.click(screen.getByText("Change Question"));
-      expect(input).toHaveValue("");
-    });
-
-    it("should make the check button visible again", async () => {
-      (global.fetch as jest.Mock).mockResolvedValueOnce({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            attemptStatus: "Success",
-            correctAnswer: "test answer",
-            questionType: "FillInTheBlanks",
-          } as FillInTheBlanksAttemptResponse),
-      });
-
-      renderWithQueryClient(<TestComponent />);
-      const input = screen.getByRole("textbox");
-      fireEvent.change(input, { target: { value: "test answer" } });
-      fireEvent.click(screen.getByText("Check"));
-
-      await waitFor(() => {
-        expect(screen.queryByText("Check")).not.toBeInTheDocument();
-      });
-
-      fireEvent.click(screen.getByText("Change Question"));
-      expect(screen.getByText("Check")).toBeInTheDocument();
-    });
-
-    it("should clear answer status", async () => {
-      (global.fetch as jest.Mock).mockResolvedValueOnce({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            attemptStatus: "Success",
-            correctAnswer: "test answer",
-            questionType: "FillInTheBlanks",
-          } as FillInTheBlanksAttemptResponse),
-      });
-
-      renderWithQueryClient(<TestComponent />);
-      fireEvent.change(screen.getByRole("textbox"), {
-        target: { value: "test answer" },
-      });
-      fireEvent.click(screen.getByText("Check"));
-
-      await waitFor(() => {
-        expect(screen.getByText(/correct/i)).toBeInTheDocument();
-      });
-
-      fireEvent.click(screen.getByText("Change Question"));
-      expect(screen.queryByText(/correct/i)).not.toBeInTheDocument();
-    });
-
-    it("should clear error state", async () => {
-      (global.fetch as jest.Mock).mockRejectedValueOnce(
-        new Error("Network error")
-      );
-
-      renderWithQueryClient(<TestComponent />);
-      fireEvent.change(screen.getByRole("textbox"), {
-        target: { value: "test answer" },
-      });
-      fireEvent.click(screen.getByText("Check"));
-
-      await waitFor(() => {
-        expect(screen.getByText(/error/i)).toBeInTheDocument();
-      });
-
-      fireEvent.click(screen.getByText("Change Question"));
-      expect(screen.queryByText(/error/i)).not.toBeInTheDocument();
-    });
-
-    it("should focus the input box when question changes", () => {
-      renderWithQueryClient(<TestComponent />);
-      const input = screen.getByRole("textbox");
-      input.blur();
-      expect(input).not.toHaveFocus();
-
-      fireEvent.click(screen.getByText("Change Question"));
-      expect(screen.getByRole("textbox")).toHaveFocus();
-    });
-  });
-});
+const checkAnswerAndChangeQuestion = async (
+  answer: string,
+  findByRole: (role: string) => Promise<HTMLElement>,
+  findByText: (text: string | RegExp) => Promise<HTMLElement>
+) => {
+  await checkAnswer(answer, findByRole, findByText);
+  const changeQuestionButton = await findByText("Change Question");
+  fireEvent.click(changeQuestionButton);
+};


### PR DESCRIPTION
### **User description**
* waitFor elements before interacting with them
* Use the new get* APIs instead of screen.get*
* Refactor repeated patterns into helper functions


___

### **PR Type**
Tests


___

### **Description**
- Refactored React test cases to improve readability and maintainability.
  - Replaced `screen.get*` with destructured `get*` APIs.
  - Added `waitFor` to ensure elements are rendered before interaction.

- Consolidated repeated patterns into reusable helper functions.
  - Introduced `mockSuccessfulAttempt`, `mockNetworkError`, and similar helpers.
  - Created `checkAnswer` and `checkAnswerAndChangeQuestion` for common test flows.

- Enhanced test structure for `LearnPage` and `FillInTheBlanks` components.
  - Improved error handling and loading state tests.
  - Simplified question navigation and state reset tests.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FillInTheBlanks.test.tsx</strong><dd><code>Refactored and enhanced `FillInTheBlanks` component tests</code></dd></summary>
<hr>

lingetic-nextjs-frontend/__tests__/components/questions/FillInTheBlanks/FillInTheBlanks.test.tsx

<li>Replaced <code>screen.get*</code> with destructured <code>get*</code> APIs.<br> <li> Added <code>waitFor</code> to ensure elements are rendered before interaction.<br> <li> Introduced helper functions for mocking API responses and common test <br>flows.<br> <li> Improved test coverage for question state changes and error handling.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/44/files#diff-334034ba9b47af0e45dadd79f2d64f8029efe1cbbc0ab34734f76d8b63b41085">+166/-152</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LearnPage.test.tsx</strong><dd><code>Refactored and enhanced `LearnPage` component tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-nextjs-frontend/__tests__/pages/learn/LearnPage.test.tsx

<li>Replaced <code>screen.get*</code> with destructured <code>get*</code> APIs.<br> <li> Added <code>waitFor</code> to ensure elements are rendered before interaction.<br> <li> Introduced helper functions for mocking API responses and navigation.<br> <li> Improved test coverage for loading, error, and navigation states.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/44/files#diff-2b0a6a311c4c133ca66b9d7d5a66db57d60165c1304fd149ac4ca68cdc962db6">+118/-139</a></td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Improved reliability of asynchronous operations to ensure interactive elements are handled correctly.
	- Standardized simulated network responses for success and error scenarios, enhancing overall error handling.
	- Refined test procedures for user input interactions and page navigation for increased maintainability.
	- Introduced new helper functions for streamlined mocking of fetch responses and improved code organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->