### PR TITLE
Fix JAVA_HOME environment variable

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -9,7 +9,7 @@ pkgs.mkShell {
   ];
 
   shellHook = ''
-    export JAVA_HOME=${pkgs.jdk23}
+    export JAVA_HOME=${pkgs.jdk23}/lib/openjdk
     export PATH=${pkgs.jdk23}/bin:$PATH
 
     echo "Node.js version: $(node --version)"


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Corrected the `JAVA_HOME` environment variable path in `shell.nix`.

- Ensured compatibility with OpenJDK by specifying the correct directory.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shell.nix</strong><dd><code>Fix `JAVA_HOME` path for OpenJDK compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

shell.nix

<li>Updated the <code>JAVA_HOME</code> environment variable to include <code>/lib/openjdk</code>.<br> <li> Ensured the correct path for OpenJDK compatibility.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/45/files#diff-e53dfbfffe62ae3c0b411b3938ccffa9fb6a2ecc565f55785ef8daa756631a6b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Java runtime configuration to point to a more precise location, ensuring reliable setup for Java-related operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->