### PR TITLE
Add unit tests for DTOs

### DIFF
--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptRequests/AttemptRequest.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptRequests/AttemptRequest.java
@@ -12,15 +12,14 @@ public sealed interface AttemptRequest permits FillInTheBlanksAttemptRequest {
 
     static AttemptRequest fromJsonNode(JsonNode node) {
         if (!node.has("questionType")) {
-            throw new IllegalArgumentException("AttemptRequest must have a type");
+            throw new IllegalArgumentException("AttemptRequest must have a questionType");
         }
 
         var typeAsStr = node.get("questionType").asText();
         var type = QuestionType.valueOf(typeAsStr);
-        
+
         return switch (type) {
             case FillInTheBlanks -> FillInTheBlanksAttemptRequest.fromJsonNode(node);
-            default -> throw new IllegalArgumentException("Invalid question type");
         };
     }
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptRequests/FillInTheBlanksAttemptRequest.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptRequests/FillInTheBlanksAttemptRequest.java
@@ -2,8 +2,12 @@ package com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
 import com.munetmo.lingetic.LanguageTestService.infra.Deserializers.AttemptRequestDeserializer;
+
+import java.util.InputMismatchException;
 
 @JsonDeserialize(using = AttemptRequestDeserializer.class)
 public final class FillInTheBlanksAttemptRequest implements AttemptRequest {
@@ -12,6 +16,13 @@ public final class FillInTheBlanksAttemptRequest implements AttemptRequest {
     private final String userResponse;
 
     public FillInTheBlanksAttemptRequest(String questionID, String userResponse) {
+        if (questionID == null || questionID.isBlank()) {
+            throw new IllegalArgumentException("questionID cannot be null.");
+        }
+        if (userResponse == null) {
+            throw new IllegalArgumentException("userResponse cannot be null.");
+        }
+
         this.questionID = questionID;
         this.userResponse = userResponse;
     }
@@ -22,9 +33,21 @@ public final class FillInTheBlanksAttemptRequest implements AttemptRequest {
     }
 
     public static FillInTheBlanksAttemptRequest fromJsonNode(JsonNode node) {
-        var questionID = node.get("questionID").asText();
-        var userResponse = node.get("userResponse").asText();
-        return new FillInTheBlanksAttemptRequest(questionID, userResponse);
+        if (node == null) {
+            throw new IllegalArgumentException("node cannot be null.");
+        }
+
+        var questionID = node.get("questionID");
+        if (questionID == null) {
+            throw new InputMismatchException("questionID is required.");
+        }
+
+        var userResponse = node.get("userResponse");
+        if (userResponse == null) {
+            throw new InputMismatchException("userResponse is required.");
+        }
+
+        return new FillInTheBlanksAttemptRequest(questionID.asText(), userResponse.asText());
     }
 
     @Override

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptResponses/FillInTheBlanksAttemptResponse.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptResponses/FillInTheBlanksAttemptResponse.java
@@ -8,7 +8,15 @@ public final class FillInTheBlanksAttemptResponse implements AttemptResponse {
     private final AttemptStatus attemptStatus;
     private final String correctAnswer;
 
-    public FillInTheBlanksAttemptResponse(AttemptStatus attemptStatus,  String correctAnswer) {
+    public FillInTheBlanksAttemptResponse(AttemptStatus attemptStatus, String correctAnswer) {
+        if (attemptStatus == null) {
+            throw new IllegalArgumentException("attemptStatus cannot be null");
+        }
+
+        if (correctAnswer == null || correctAnswer.isBlank()) {
+            throw new IllegalArgumentException("correctAnswer cannot be null or blank.");
+        }
+
         this.attemptStatus = attemptStatus;
         this.correctAnswer = correctAnswer;
     }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/FillInTheBlanksQuestionDTO.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/FillInTheBlanksQuestionDTO.java
@@ -3,22 +3,24 @@ package com.munetmo.lingetic.LanguageTestService.DTOs.Question;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
 import java.util.Objects;
 
-public record FillInTheBlanksQuestionDTO(String id, String text, String hint) implements QuestionDTO {
+public final class FillInTheBlanksQuestionDTO implements QuestionDTO {
     public static final QuestionType questionType = QuestionType.FillInTheBlanks;
+    private final String id;
+    public final String text;
+    public final String hint;
 
-    public FillInTheBlanksQuestionDTO {
-        Objects.requireNonNull(id, "id must not be null");
-        if (id.isBlank()) {
-            throw new IllegalArgumentException("id must not be blank");
+    public FillInTheBlanksQuestionDTO(String id, String text, String hint) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("id must not be blank or null");
         }
 
-        Objects.requireNonNull(text, "text must not be null");
-        if (text.isBlank()) {
+        if (text == null || text.isBlank()) {
             throw new IllegalArgumentException("text must not be blank");
         }
 
-        hint = Objects.requireNonNullElse(hint, "");
-
+        this.id = id;
+        this.text = text;
+        this.hint = Objects.requireNonNullElse(hint, "");
     }
 
     public String getID() {
@@ -28,5 +30,13 @@ public record FillInTheBlanksQuestionDTO(String id, String text, String hint) im
     @Override
     public QuestionType getQuestionType() {
         return questionType;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public String getHint() {
+        return hint;
     }
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/QuestionDTO.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/QuestionDTO.java
@@ -9,12 +9,15 @@ public sealed interface QuestionDTO permits FillInTheBlanksQuestionDTO {
     QuestionType getQuestionType();
 
     static QuestionDTO fromQuestion(Question question) {
-        switch (question.getQuestionType()) {
+        if (question == null) {
+            throw new IllegalArgumentException("question cannot be null.");
+        }
+
+        return switch (question.getQuestionType()) {
             case FillInTheBlanks -> {
                 var typedQuestion = (FillInTheBlanksQuestion)question;
-                return new FillInTheBlanksQuestionDTO(question.getID(), typedQuestion.questionText, typedQuestion.hint);
+                yield new FillInTheBlanksQuestionDTO(typedQuestion.getID(), typedQuestion.questionText, typedQuestion.hint);
             }
-            default -> throw new IllegalArgumentException("Unsupported question type");
-        }
+        };
     }
 }

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptRequests/AttemptRequestTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptRequests/AttemptRequestTest.java
@@ -1,0 +1,62 @@
+package com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AttemptRequestTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void shouldThrowExceptionWhenQuestionTypeMissing() throws JsonProcessingException {
+        var json = """
+            {
+                "questionID": "123"
+            }
+            """;
+        var node = objectMapper.readTree(json);
+
+        var exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> AttemptRequest.fromJsonNode(node)
+        );
+        assertTrue(exception.getMessage().contains("questionType"));
+    }
+
+    @Test
+    void shouldThrowExceptionForInvalidQuestionType() throws JsonProcessingException {
+        var json = """
+            {
+                "questionType": "ExampleInvalidType",
+                "questionID": "123"
+            }
+            """;
+        var node = objectMapper.readTree(json);
+        
+        var exception = assertThrows(IllegalArgumentException.class, () -> AttemptRequest.fromJsonNode(node));
+        assertTrue(exception.getMessage().contains("ExampleInvalidType"));
+    }
+
+    @Test
+    void shouldCreateFillInTheBlanksRequestWhenTypeMatches() throws JsonProcessingException {
+        var json = """
+            {
+                "questionType": "FillInTheBlanks",
+                "questionID": "123",
+                "userResponse": "test answer"
+            }
+            """;
+        var node = objectMapper.readTree(json);
+        
+        var request = AttemptRequest.fromJsonNode(node);
+
+        assertInstanceOf(FillInTheBlanksAttemptRequest.class, request);
+
+        var fillInBlanksRequest = (FillInTheBlanksAttemptRequest) request;
+        assertEquals("123", fillInBlanksRequest.getQuestionID());
+        assertEquals("test answer", fillInBlanksRequest.getUserResponse());
+        assertEquals(QuestionType.FillInTheBlanks, fillInBlanksRequest.getQuestionType());
+    }
+}

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptRequests/FillInTheBlanksAttemptRequestTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptRequests/FillInTheBlanksAttemptRequestTest.java
@@ -1,0 +1,108 @@
+package com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
+import org.junit.jupiter.api.Test;
+
+import java.util.InputMismatchException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FillInTheBlanksAttemptRequestTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void constructorShouldThrowExceptionWhenQuestionIDIsNull() {
+        var exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> new FillInTheBlanksAttemptRequest(null, "answer")
+        );
+        assertTrue(exception.getMessage().contains("questionID"));
+    }
+
+    @Test
+    void constructorShouldThrowExceptionWhenQuestionIDIsBlank() {
+        var exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> new FillInTheBlanksAttemptRequest("", "answer")
+        );
+        assertTrue(exception.getMessage().contains("questionID"));
+    }
+
+    @Test
+    void constructorShouldThrowExceptionWhenUserResponseIsNull() {
+        var exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> new FillInTheBlanksAttemptRequest("123", null)
+        );
+        assertTrue(exception.getMessage().contains("userResponse"));
+    }
+
+    @Test
+    void constructorShouldCreateAValidObjectWhenGivenValidArguments() {
+        var request = new FillInTheBlanksAttemptRequest("test-id", "test-response");
+
+        assertEquals("test-id", request.getQuestionID());
+        assertEquals("test-response", request.getUserResponse());
+        assertEquals(QuestionType.FillInTheBlanks, request.getQuestionType());
+    }
+
+    @Test
+    void fromJsonNodeShouldThrowExceptionWhenNodeIsNull() {
+        var exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> FillInTheBlanksAttemptRequest.fromJsonNode(null)
+        );
+        assertTrue(exception.getMessage().contains("node"));
+    }
+
+    @Test
+    void fromJsonNodeShouldThrowExceptionWhenQuestionIDIsMissing() throws JsonProcessingException {
+        var json = """
+            {
+                "userResponse": "test answer"
+            }
+            """;
+        var node = objectMapper.readTree(json);
+        
+        var exception = assertThrows(
+            InputMismatchException.class,
+            () -> FillInTheBlanksAttemptRequest.fromJsonNode(node)
+        );
+        assertTrue(exception.getMessage().contains("questionID"));
+    }
+
+    @Test
+    void fromJsonNodeShouldThrowExceptionWhenUserResponseIsMissing() throws JsonProcessingException {
+        var json = """
+            {
+                "questionID": "123"
+            }
+            """;
+        var node = objectMapper.readTree(json);
+
+        var exception = assertThrows(
+            InputMismatchException.class,
+            () -> FillInTheBlanksAttemptRequest.fromJsonNode(node)
+        );
+        assertTrue(exception.getMessage().contains("userResponse"));
+    }
+
+    @Test
+    void shouldCreateValidRequestFromValidJson() throws JsonProcessingException {
+        var json = """
+            {
+                "questionID": "123",
+                "userResponse": "test answer"
+            }
+            """;
+        var node = objectMapper.readTree(json);
+
+        var request = FillInTheBlanksAttemptRequest.fromJsonNode(node);
+
+        assertEquals("123", request.getQuestionID());
+        assertEquals("test answer", request.getUserResponse());
+        assertEquals(QuestionType.FillInTheBlanks, request.getQuestionType());
+    }
+}

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptResponses/FillInTheBlanksAttemptResponseTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptResponses/FillInTheBlanksAttemptResponseTest.java
@@ -1,0 +1,45 @@
+package com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses;
+
+import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
+import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FillInTheBlanksAttemptResponseTest {
+    @Test
+    void constructorShouldCreateValidObjectWithCorrectValues() {
+        var response = new FillInTheBlanksAttemptResponse(AttemptStatus.Success, "test answer");
+
+        assertEquals(AttemptStatus.Success, response.getAttemptStatus());
+        assertEquals("test answer", response.getCorrectAnswer());
+        assertEquals(QuestionType.FillInTheBlanks, response.getQuestionType());
+    }
+
+    @Test
+    void constructorShouldThrowExceptionWhenAttemptStatusIsNull() {
+        var exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> new FillInTheBlanksAttemptResponse(null, "test answer")
+        );
+        assertTrue(exception.getMessage().contains("attemptStatus"));
+    }
+
+    @Test
+    void constructorShouldThrowExceptionWhenCorrectAnswerIsNull() {
+        var exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> new FillInTheBlanksAttemptResponse(AttemptStatus.Success, null)
+        );
+        assertTrue(exception.getMessage().contains("correctAnswer"));
+    }
+
+    @Test
+    void constructorShouldThrowExceptionWhenCorrectAnswerIsBlank() {
+        var exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> new FillInTheBlanksAttemptResponse(AttemptStatus.Success, "")
+        );
+        assertTrue(exception.getMessage().contains("correctAnswer"));
+    }
+}

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/FillInTheBlanksQuestionDTOTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/FillInTheBlanksQuestionDTOTest.java
@@ -15,32 +15,40 @@ public class FillInTheBlanksQuestionDTOTest {
 
         assertEquals("q123", question.getID());
         assertEquals(QuestionType.FillInTheBlanks, question.getQuestionType());
-        assertEquals("Fill in: ___", question.text());
-        assertEquals("This is a hint", question.hint());
+        assertEquals("Fill in: ___", question.getText());
+        assertEquals("This is a hint", question.getHint());
     }
 
     @Test
     void shouldThrowExceptionWhenIdIsNull() {
-        assertThrows(NullPointerException.class, () -> new FillInTheBlanksQuestionDTO(null, "Fill in: ___", "This is a hint"));
+        var exception = assertThrows(IllegalArgumentException.class, () -> new FillInTheBlanksQuestionDTO(
+                null, "Fill in: ___", "This is a hint"));
+        assertTrue(exception.getMessage().contains("id"));
     }
 
     @Test
     void shouldThrowExceptionWhenIdIsBlank() {
-        assertThrows(IllegalArgumentException.class, () -> new FillInTheBlanksQuestionDTO("", "Fill in: ___", "This is a hint"));
+        var exception = assertThrows(IllegalArgumentException.class, () -> new FillInTheBlanksQuestionDTO(
+                "", "Fill in: ___", "This is a hint"));
+        assertTrue(exception.getMessage().contains("id"));
     }
 
     @Test
-    void shouldThrowExceptionWhenTextIsNull() {
-        assertThrows(NullPointerException.class, () -> new FillInTheBlanksQuestionDTO("q123", null, "This is a hint"));
+    void shouldThrowExceptionWhenGetTextIsNull() {
+        var exception = assertThrows(IllegalArgumentException.class, () -> new FillInTheBlanksQuestionDTO(
+                "q123", null, "This is a hint"));
+        assertTrue(exception.getMessage().contains("text"));
     }
 
     @Test
-    void shouldThrowExceptionWhenTextIsBlank() {
-        assertThrows(IllegalArgumentException.class, () -> new FillInTheBlanksQuestionDTO("q123", "", "This is a hint"));
+    void shouldThrowExceptionWhenGetTextIsBlank() {
+        var exception = assertThrows(IllegalArgumentException.class, () -> new FillInTheBlanksQuestionDTO(
+                "q123", "", "This is a hint"));
+        assertTrue(exception.getMessage().contains("text"));
     }
 
     @Test
-    void shouldCreateQuestionDTOWithoutHint() {
+    void shouldCreateQuestionDTOWithoutGetHint() {
         FillInTheBlanksQuestionDTO question = new FillInTheBlanksQuestionDTO(
                 "q123",
                 "Fill in: ___",
@@ -48,12 +56,12 @@ public class FillInTheBlanksQuestionDTOTest {
 
         assertEquals("q123", question.getID());
         assertEquals(QuestionType.FillInTheBlanks, question.getQuestionType());
-        assertEquals("Fill in: ___", question.text());
-        assertEquals("", question.hint());
+        assertEquals("Fill in: ___", question.getText());
+        assertEquals("", question.getHint());
     }
 
     @Test
-    void shouldCreateQuestionDTOWithEmptyHint() {
+    void shouldCreateQuestionDTOWithEmptyGetHint() {
         FillInTheBlanksQuestionDTO question = new FillInTheBlanksQuestionDTO(
                 "q123",
                 "Fill in: ___",
@@ -61,7 +69,7 @@ public class FillInTheBlanksQuestionDTOTest {
 
         assertEquals("q123", question.getID());
         assertEquals(QuestionType.FillInTheBlanks, question.getQuestionType());
-        assertEquals("Fill in: ___", question.text());
-        assertEquals("", question.hint());
+        assertEquals("Fill in: ___", question.getText());
+        assertEquals("", question.getHint());
     }
 }

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/QuestionDTOTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/QuestionDTOTest.java
@@ -1,0 +1,32 @@
+package com.munetmo.lingetic.LanguageTestService.DTOs.Question;
+
+import com.munetmo.lingetic.LanguageTestService.Entities.Questions.FillInTheBlanksQuestion;
+import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class QuestionDTOTest {
+
+    @Test
+    void shouldConvertFillInTheBlanksQuestionToDTO() {
+        FillInTheBlanksQuestion question = new FillInTheBlanksQuestion(
+            "q123", 
+            "Fill in: ___", 
+            "This is a hint",
+            "test answer"
+        );
+
+        QuestionDTO dto = QuestionDTO.fromQuestion(question);
+
+        assertInstanceOf(FillInTheBlanksQuestionDTO.class, dto);
+        assertEquals("q123", dto.getID());
+        assertEquals(QuestionType.FillInTheBlanks, dto.getQuestionType());
+        assertEquals("Fill in: ___", ((FillInTheBlanksQuestionDTO) dto).getText());
+        assertEquals("This is a hint", ((FillInTheBlanksQuestionDTO) dto).getHint());
+    }
+
+    @Test
+    void shouldThrowIllegalArgumentExceptionIfPassedQuestionIsNull() {
+        assertThrows(IllegalArgumentException.class, () -> QuestionDTO.fromQuestion(null));
+    }
+}


### PR DESCRIPTION
### **User description**
Also, make those unit tests pass.


___

### **PR Type**
Tests, Enhancement


___

### **Description**
- Added comprehensive unit tests for DTOs.
  - Covered `AttemptRequest`, `FillInTheBlanksAttemptRequest`, `FillInTheBlanksAttemptResponse`, and `QuestionDTO`.

- Enhanced validation in DTO constructors and methods.
  - Added null and blank checks for critical fields.

- Improved error handling for invalid or missing input data.
  - Introduced specific exceptions for better clarity.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>AttemptRequest.java</strong><dd><code>Improved error handling for missing questionType</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/46/files#diff-85a7e1d3487222ce061a1d030cb0d336be4e26521aee07c3930fe8de3ef3a89e">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>FillInTheBlanksAttemptRequest.java</strong><dd><code>Enhanced validation and error handling for </code><br><code>FillInTheBlanksAttemptRequest</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/46/files#diff-33c0531853954ee93407ae9b1689820e4df2174c20b17c66c5d294682424616b">+26/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>FillInTheBlanksAttemptResponse.java</strong><dd><code>Added validation for constructor arguments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/46/files#diff-a38a2a0ffa1bfe15d55954e53b6089c251a2d49d2fc668f9c48f9f80c6e691dd">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>FillInTheBlanksQuestionDTO.java</strong><dd><code>Converted record to class and added validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/46/files#diff-fa213b6fcea598170beee82aacbd0950ae8777132b472697dac49c121e887ce6">+19/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>QuestionDTO.java</strong><dd><code>Improved error handling for null questions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/46/files#diff-b4f6d517766f87823fff5027e68bcd672c3e16ba706f87202ed475de7eee4eeb">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>AttemptRequestTest.java</strong><dd><code>Added unit tests for AttemptRequest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/46/files#diff-e47262c9ed5d8fe30913c10086ddb9175b87646502cec6d60e7963ae9ab7b3bd">+62/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>FillInTheBlanksAttemptRequestTest.java</strong><dd><code>Added unit tests for FillInTheBlanksAttemptRequest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/46/files#diff-58d55b7f00437dc4cf875038047b7ffe26e4f5d7a6bed93c24333f3b1da35e7c">+108/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>FillInTheBlanksAttemptResponseTest.java</strong><dd><code>Added unit tests for FillInTheBlanksAttemptResponse</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/46/files#diff-9d97ce481b0b6cc8b60f717a8d4b7ad4ce960198d9538c46945b2918300bdc72">+45/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>FillInTheBlanksQuestionDTOTest.java</strong><dd><code>Added unit tests for FillInTheBlanksQuestionDTO</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/46/files#diff-5ba7be7435286726432203ffa1e026197c626b84f55b52a0266050595d0c3b04">+22/-14</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>QuestionDTOTest.java</strong><dd><code>Added unit tests for QuestionDTO</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/46/files#diff-a6903e4b0031d84c303aa4c979ef61300fe747c0a8edd8510272e4d2b6457ee9">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
	- Streamlined error messages now clearly indicate when required fields (such as the question type) are missing or invalid.
	- Enhanced validations ensure that all essential details for fill-in-the-blanks questions—like identifiers and responses—are provided, preventing incomplete submissions.
	- Improved handling of question input results in more consistent, reliable feedback for test responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->