### PR TITLE
Add passing unit tests for FillInTheBlanksQuestion

### DIFF
--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestion.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestion.java
@@ -15,6 +15,22 @@ public final class FillInTheBlanksQuestion implements Question {
     public final String answer;
 
     public FillInTheBlanksQuestion(String id, String questionText, String hint, String answer) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("ID cannot be null or blank");
+        }
+
+        if (questionText == null || questionText.isBlank()) {
+            throw new IllegalArgumentException("Question text cannot be null or blank");
+        }
+
+        if (!questionText.matches("^[^_]*_+[^_]*$")) {
+            throw new IllegalArgumentException("Question text must contain exactly one blank");
+        }
+
+        if (answer == null || answer.isBlank()) {
+            throw new IllegalArgumentException("Answer cannot be null or blank");
+        }
+
         this.id = id;
         this.questionText = questionText;
         this.hint = hint;
@@ -36,7 +52,7 @@ public final class FillInTheBlanksQuestion implements Question {
         if (!(request instanceof FillInTheBlanksAttemptRequest typedRequest)) {
             throw new IllegalArgumentException("Invalid request type");
         }
-        
+
         return new FillInTheBlanksAttemptResponse(
             typedRequest.getUserResponse().equals(answer) ? AttemptStatus.Success : AttemptStatus.Failure,
             answer

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestionTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestionTest.java
@@ -1,0 +1,99 @@
+package com.munetmo.lingetic.LanguageTestService.Entities.Questions;
+
+import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests.FillInTheBlanksAttemptRequest;
+import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.FillInTheBlanksAttemptResponse;
+import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FillInTheBlanksQuestionTest {
+    @Test
+    void constructorShouldCreateValidObjectWithCorrectValues() {
+        var id = "test-id";
+        var questionText = "Fill in the ___";
+        var hint = "test hint";
+        var answer = "blank";
+
+        FillInTheBlanksQuestion question = new FillInTheBlanksQuestion(id, questionText, hint, answer);
+
+        assertEquals(id, question.getID());
+        assertEquals(QuestionType.FillInTheBlanks, question.getQuestionType());
+        assertEquals(questionText, question.questionText);
+        assertEquals(hint, question.hint);
+        assertEquals(answer, question.answer);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {" ", "   ", "\t", "\n"})
+    void constructorShouldThrowExceptionWhenIdIsInvalid(String id) {
+        assertThrows(IllegalArgumentException.class, () ->
+            new FillInTheBlanksQuestion(id, "Fill in the ___", "hint", "answer")
+        );
+    }
+
+    @Test
+    void constructorShouldThrowExceptionWhenIdIsNull() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new FillInTheBlanksQuestion(null, "Fill in the ___", "hint", "answer")
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "   ", "\t", "\n", "No blank here", "Multiple___ ___blanks", "Wrong blank --"})
+    void constructorShouldThrowExceptionWhenQuestionTextIsInvalid(String questionText) {
+        assertThrows(IllegalArgumentException.class, () ->
+            new FillInTheBlanksQuestion("id", questionText, "hint", "answer")
+        );
+    }
+
+    @Test
+    void constructorShouldThrowExceptionWhenQuestionTextIsNull() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new FillInTheBlanksQuestion("id", null, "hint", "answer")
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "   ", "\t", "\n"})
+    void constructorShouldThrowExceptionWhenAnswerIsInvalid(String answer) {
+        assertThrows(IllegalArgumentException.class, () ->
+            new FillInTheBlanksQuestion("id", "Fill in the ___", "hint", answer)
+        );
+    }
+
+    @Test
+    void constructorShouldThrowExceptionWhenAnswerIsNull() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new FillInTheBlanksQuestion("id", "Fill in the ___", "hint", null)
+        );
+    }
+
+    @Test
+    void assessAttemptShouldReturnSuccessForCorrectAnswer() {
+        var question = new FillInTheBlanksQuestion(
+            "id", "Fill in the ___", "hint", "correct"
+        );
+        var request = new FillInTheBlanksAttemptRequest(question.getID(), question.answer);
+
+        var response = (FillInTheBlanksAttemptResponse) question.assessAttempt(request);
+
+        assertEquals(AttemptStatus.Success, response.getAttemptStatus());
+        assertEquals(question.answer, response.getCorrectAnswer());
+    }
+
+    @Test
+    void assessAttemptShouldReturnFailureForIncorrectAnswer() {
+        var question = new FillInTheBlanksQuestion(
+            "id", "Fill in the ___", "hint", "correct"
+        );
+        var request = new FillInTheBlanksAttemptRequest(question.getID(), "wrong");
+
+        var response = (FillInTheBlanksAttemptResponse) question.assessAttempt(request);
+
+        assertEquals(AttemptStatus.Failure, response.getAttemptStatus());
+        assertEquals(question.answer, response.getCorrectAnswer());
+    }
+}


### PR DESCRIPTION
### **PR Type**
Tests, Enhancement


___

### **Description**
- Added validation checks in `FillInTheBlanksQuestion` constructor.

- Implemented unit tests for `FillInTheBlanksQuestion` class.

- Enhanced error handling for invalid inputs in `FillInTheBlanksQuestion`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FillInTheBlanksQuestion.java</strong><dd><code>Add validation checks in FillInTheBlanksQuestion constructor</code></dd></summary>
<hr>

lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestion.java

<li>Added validation for <code>id</code>, <code>questionText</code>, and <code>answer</code> in the constructor.<br> <li> Enforced constraints on <code>questionText</code> to ensure exactly one blank.<br> <li> Improved error handling with specific exception messages.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/47/files#diff-9d7d86a8c1cbe2e930918d9e5a4021a7c1d4930d95984dc745674893181140f3">+17/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FillInTheBlanksQuestionTest.java</strong><dd><code>Add unit tests for FillInTheBlanksQuestion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestionTest.java

<li>Added unit tests for valid constructor inputs.<br> <li> Added parameterized tests for invalid <code>id</code>, <code>questionText</code>, and <code>answer</code>.<br> <li> Tested <code>assessAttempt</code> method for success and failure cases.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/47/files#diff-0a3416aadee18c0ed2c84823014f4921e4d5f6f02115bfda63a633e1d265a867">+99/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
	- Enhanced validation for fill-in-the-blanks questions now ensures the input meets expected formatting and provides clearer feedback on invalid entries.
- Tests
	- Added comprehensive tests to verify correct question setup and answer assessment, ensuring reliable performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->