### PR TITLE
Throw more specific exception

### DIFF
--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Exceptions/QuestionNotFoundException.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Exceptions/QuestionNotFoundException.java
@@ -1,0 +1,7 @@
+package com.munetmo.lingetic.LanguageTestService.Exceptions;
+
+public class QuestionNotFoundException extends RuntimeException {
+    public QuestionNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Repositories/QuestionRepository.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Repositories/QuestionRepository.java
@@ -1,10 +1,11 @@
 package com.munetmo.lingetic.LanguageTestService.Repositories;
 
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.Question;
+import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionNotFoundException;
 
 import java.util.List;
 
 public interface QuestionRepository {
-    Question getQuestionByID(String id) throws Exception;
+    Question getQuestionByID(String id) throws QuestionNotFoundException;
     List<Question> getAllQuestions();
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCase.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCase.java
@@ -2,6 +2,7 @@ package com.munetmo.lingetic.LanguageTestService.UseCases;
 
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests.AttemptRequest;
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.AttemptResponse;
+import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionNotFoundException;
 import com.munetmo.lingetic.LanguageTestService.Repositories.QuestionRepository;
 
 public class AttemptQuestionUseCase {
@@ -11,7 +12,7 @@ public class AttemptQuestionUseCase {
         this.questionRepository = questionRepository;
     }
 
-    public AttemptResponse execute(AttemptRequest request) throws Exception {
+    public AttemptResponse execute(AttemptRequest request) throws QuestionNotFoundException {
         var question = questionRepository.getQuestionByID(request.getQuestionID());
         return question.assessAttempt(request);
     }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/HTTP/QuestionsController.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/HTTP/QuestionsController.java
@@ -2,6 +2,7 @@ package com.munetmo.lingetic.LanguageTestService.infra.HTTP;
 
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests.AttemptRequest;
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.AttemptResponse;
+import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionNotFoundException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,7 +31,7 @@ public class QuestionsController {
     }
 
     @PostMapping("/attempt")
-    public ResponseEntity<AttemptResponse> attemptQuestion(@RequestBody AttemptRequest request) throws Exception {
+    public ResponseEntity<AttemptResponse> attemptQuestion(@RequestBody AttemptRequest request) throws QuestionNotFoundException {
         var response = attemptQuestionUseCase.execute(request);
         return ResponseEntity.ok(response);
     }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/Repositories/InMemory/QuestionInMemoryRepository.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/Repositories/InMemory/QuestionInMemoryRepository.java
@@ -3,6 +3,7 @@ package com.munetmo.lingetic.LanguageTestService.infra.Repositories.InMemory;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.Question;
 import com.munetmo.lingetic.LanguageTestService.Repositories.QuestionRepository;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.FillInTheBlanksQuestion;
+import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionNotFoundException;
 
 import java.util.List;
 
@@ -71,12 +72,11 @@ public class QuestionInMemoryRepository implements QuestionRepository {
     );
 
     @Override
-    public Question getQuestionByID(String id) throws Exception {
+    public Question getQuestionByID(String id) throws QuestionNotFoundException {
         var foundQuestion = QUESTIONS.stream().filter(q -> q.getID().equals(id)).findFirst().orElse(null);
         if (foundQuestion == null) {
-            throw new Exception("Question not found.");
+            throw new QuestionNotFoundException("Question with ID %s not found.".formatted(id));
         }
-
         return foundQuestion;
     }
 


### PR DESCRIPTION
### **User description**
* Instead of throwing Exception, throw
  QuestionNotFoundException from getQuestionByID.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Introduced a new `QuestionNotFoundException` for better error specificity.

- Replaced generic `Exception` with `QuestionNotFoundException` in relevant methods.

- Updated repository and use case implementations to throw the new exception.

- Improved error handling in HTTP controller and in-memory repository.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>QuestionNotFoundException.java</strong><dd><code>Introduced <code>QuestionNotFoundException</code> class for specific error handling</code></dd></summary>
<hr>

lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Exceptions/QuestionNotFoundException.java

<li>Added a new <code>QuestionNotFoundException</code> class.<br> <li> Extended <code>RuntimeException</code> to provide a specific error type.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/48/files#diff-8aee7e53b4b57c35c56639bf5d9f373617f66084821d2b5a3636dd72224c0696">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>QuestionRepository.java</strong><dd><code>Updated repository interface to use specific exception</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Repositories/QuestionRepository.java

<li>Replaced <code>Exception</code> with <code>QuestionNotFoundException</code> in <code>getQuestionByID</code>.<br> <li> Updated method signature to reflect the specific exception.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/48/files#diff-78255af545c8812fb069c5bdfef2377c32dff887364e0adde53987da44ae09d7">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AttemptQuestionUseCase.java</strong><dd><code>Updated use case to handle specific exception</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCase.java

<li>Replaced <code>Exception</code> with <code>QuestionNotFoundException</code> in <code>execute</code> method.<br> <li> Updated method signature to reflect the specific exception.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/48/files#diff-b9cdd01806c5f1a01ec65a1cca563180c208e58850957f2309637118b7a606c3">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>QuestionsController.java</strong><dd><code>Updated HTTP controller to handle specific exception</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/HTTP/QuestionsController.java

<li>Replaced <code>Exception</code> with <code>QuestionNotFoundException</code> in <code>attemptQuestion</code>.<br> <li> Updated method signature to reflect the specific exception.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/48/files#diff-c36dc4682e666603d6c2c01dc252f4c96ff6b4983613f5985e8e8fb5613e7bb2">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>QuestionInMemoryRepository.java</strong><dd><code>Updated in-memory repository to throw specific exception</code>&nbsp; </dd></summary>
<hr>

lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/Repositories/InMemory/QuestionInMemoryRepository.java

<li>Replaced <code>Exception</code> with <code>QuestionNotFoundException</code> in <code>getQuestionByID</code>.<br> <li> Improved error message with specific details.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/48/files#diff-cf743cff6036639351429427a97c9d2459d8f5c3480a16109d5d736f50833f0f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced error handling in language test flows. Users now receive clearer, more specific notifications when a question cannot be found instead of a generic error message, leading to improved troubleshooting and a smoother test experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->