### PR TITLE
Add passing unit tests for use cases

### DIFF
--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCase.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCase.java
@@ -6,13 +6,17 @@ import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionNotFoundExcep
 import com.munetmo.lingetic.LanguageTestService.Repositories.QuestionRepository;
 
 public class AttemptQuestionUseCase {
-    private QuestionRepository questionRepository;
+    private final QuestionRepository questionRepository;
 
     public AttemptQuestionUseCase(QuestionRepository questionRepository) {
         this.questionRepository = questionRepository;
     }
 
     public AttemptResponse execute(AttemptRequest request) throws QuestionNotFoundException {
+        if (request == null) {
+            throw new IllegalArgumentException("Attempt request cannot be null");
+        }
+
         var question = questionRepository.getQuestionByID(request.getQuestionID());
         return question.assessAttempt(request);
     }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/UseCases/TakeRegularTestUseCase.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/UseCases/TakeRegularTestUseCase.java
@@ -6,13 +6,18 @@ import com.munetmo.lingetic.LanguageTestService.DTOs.Question.*;
 import com.munetmo.lingetic.LanguageTestService.Repositories.QuestionRepository;
 
 public class TakeRegularTestUseCase {
-    private QuestionRepository questionRepository;
+    public static final int limit = 10;
+
+    private final QuestionRepository questionRepository;
 
     public TakeRegularTestUseCase(QuestionRepository questionRepository) {
         this.questionRepository = questionRepository;
     }
 
     public List<QuestionDTO> execute() {
-        return questionRepository.getAllQuestions().stream().map(QuestionDTO::fromQuestion).toList();
+        return questionRepository.getAllQuestions().stream()
+            .limit(limit)
+            .map(QuestionDTO::fromQuestion)
+            .toList();
     }
 }

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCaseTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCaseTest.java
@@ -1,0 +1,61 @@
+package com.munetmo.lingetic.LanguageTestService.UseCases;
+
+import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests.AttemptRequest;
+import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests.FillInTheBlanksAttemptRequest;
+import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.AttemptResponse;
+import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
+import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionNotFoundException;
+import com.munetmo.lingetic.LanguageTestService.infra.Repositories.InMemory.QuestionInMemoryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AttemptQuestionUseCaseTest {
+    private AttemptQuestionUseCase attemptQuestionUseCase;
+
+    @BeforeEach
+    void setUp() {
+        var questionRepository = new QuestionInMemoryRepository();
+        attemptQuestionUseCase = new AttemptQuestionUseCase(questionRepository);
+    }
+
+    @Test
+    void shouldReturnCorrectResponseForValidAttempt() throws QuestionNotFoundException {
+        var questionId = "1";
+        var request = new FillInTheBlanksAttemptRequest(questionId, "stretched");
+
+        AttemptResponse response = attemptQuestionUseCase.execute(request);
+
+        assertNotNull(response);
+        assertSame(AttemptStatus.Success, response.getAttemptStatus());
+    }
+
+    @Test
+    void shouldReturnIncorrectResponseForInvalidAttempt() throws QuestionNotFoundException {
+        var questionId = "1";
+        var request = new FillInTheBlanksAttemptRequest(questionId, "wrong answer");
+
+        AttemptResponse response = attemptQuestionUseCase.execute(request);
+
+        assertNotNull(response);
+        assertSame(AttemptStatus.Failure, response.getAttemptStatus());
+    }
+
+    @Test
+    void shouldThrowQuestionNotFoundExceptionForNonexistentQuestion() {
+        var questionId = "999";
+        var request = new FillInTheBlanksAttemptRequest(questionId, "test answer");
+
+        assertThrows(QuestionNotFoundException.class, () -> {
+            attemptQuestionUseCase.execute(request);
+        });
+    }
+
+    @Test
+    void shouldThrowIllegalArgumentExceptionForNullRequest() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            attemptQuestionUseCase.execute(null);
+        });
+    }
+}

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/TakeRegularTestUseCaseTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/TakeRegularTestUseCaseTest.java
@@ -1,0 +1,30 @@
+package com.munetmo.lingetic.LanguageTestService.UseCases;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.munetmo.lingetic.LanguageTestService.DTOs.Question.QuestionDTO;
+import com.munetmo.lingetic.LanguageTestService.infra.Repositories.InMemory.QuestionInMemoryRepository;
+
+class TakeRegularTestUseCaseTest {
+    private TakeRegularTestUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        QuestionInMemoryRepository repository = new QuestionInMemoryRepository();
+        useCase = new TakeRegularTestUseCase(repository);
+    }
+
+    @Test
+    void shouldReturnAllQuestionsAsQuestionDTOs() {
+        List<QuestionDTO> result = useCase.execute();
+
+        assertTrue(result.size() <= TakeRegularTestUseCase.limit);
+        assertTrue(result.stream().allMatch(Objects::nonNull));
+    }
+}


### PR DESCRIPTION
### **PR Type**
Tests, Enhancement


___

### **Description**
- Added unit tests for `AttemptQuestionUseCase` and `TakeRegularTestUseCase`.

- Enhanced `AttemptQuestionUseCase` with null request validation.

- Limited results in `TakeRegularTestUseCase` to a maximum of 10 questions.

- Refactored repositories to use `final` for immutability.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AttemptQuestionUseCase.java</strong><dd><code>Add null request validation and refactor repository</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCase.java

<li>Added null request validation with <code>IllegalArgumentException</code>.<br> <li> Refactored <code>questionRepository</code> to be <code>final</code>.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/49/files#diff-b9cdd01806c5f1a01ec65a1cca563180c208e58850957f2309637118b7a606c3">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TakeRegularTestUseCase.java</strong><dd><code>Limit results and refactor repository</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/UseCases/TakeRegularTestUseCase.java

<li>Limited results to 10 questions using <code>limit</code>.<br> <li> Refactored <code>questionRepository</code> to be <code>final</code>.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/49/files#diff-572f192a7c115ca5a0e26ca31f1578afe9f28f391794233cf01295f3a33c4be3">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AttemptQuestionUseCaseTest.java</strong><dd><code>Add unit tests for `AttemptQuestionUseCase`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCaseTest.java

<li>Added unit tests for valid and invalid attempts.<br> <li> Tested exception handling for null requests and nonexistent questions.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/49/files#diff-6564db7713f761ac261226011bd4890a7331c730ae57545f0ca164f5c2eadc79">+61/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TakeRegularTestUseCaseTest.java</strong><dd><code>Add unit tests for `TakeRegularTestUseCase`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/TakeRegularTestUseCaseTest.java

<li>Added unit test to validate question limit functionality.<br> <li> Verified all returned questions are non-null.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/49/files#diff-a6198b6ed08529c39d68e286f8a8517ca2237e510b1ac4a965e037d8a17a5c45">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Regular tests now return a fixed number of questions for a more streamlined testing experience.

- **Bug Fixes**
	- Enhanced error handling ensures that invalid or missing attempt details are clearly flagged.

- **Tests**
	- Introduced comprehensive tests validating both the attempt and test-taking functionalities for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->