### PR TITLE
Return 404 when question is not found

### DIFF
--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/HTTP/QuestionsController.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/HTTP/QuestionsController.java
@@ -1,8 +1,8 @@
 package com.munetmo.lingetic.LanguageTestService.infra.HTTP;
 
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests.AttemptRequest;
-import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.AttemptResponse;
 import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionNotFoundException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,8 +31,12 @@ public class QuestionsController {
     }
 
     @PostMapping("/attempt")
-    public ResponseEntity<AttemptResponse> attemptQuestion(@RequestBody AttemptRequest request) throws QuestionNotFoundException {
-        var response = attemptQuestionUseCase.execute(request);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<?> attemptQuestion(@RequestBody AttemptRequest request) {
+        try {
+            var response = attemptQuestionUseCase.execute(request);
+            return ResponseEntity.ok(response);
+        } catch (QuestionNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Question not found");
+        }
     }
 }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Return a 404 status when a question is not found.

- Add error handling for `QuestionNotFoundException` in `attemptQuestion` method.

- Replace specific response type with generic `ResponseEntity<?>` for flexibility.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>QuestionsController.java</strong><dd><code>Add 404 error handling for missing questions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/HTTP/QuestionsController.java

<li>Added try-catch block to handle <code>QuestionNotFoundException</code>.<br> <li> Return 404 status with "Question not found" message on exception.<br> <li> Changed method response type to <code>ResponseEntity<?></code> for broader <br>compatibility.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/50/files#diff-c36dc4682e666603d6c2c01dc252f4c96ff6b4983613f5985e8e8fb5613e7bb2">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the question attempt process to provide clearer feedback. When a question isn’t available, users now receive a definitive 404 error along with a "Question not found" message, ensuring a smoother and more informative experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->