### PR TITLE
Add filtering by language in take regular test

### DIFF
--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/FillInTheBlanksQuestionDTO.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/FillInTheBlanksQuestionDTO.java
@@ -6,12 +6,17 @@ import java.util.Objects;
 public final class FillInTheBlanksQuestionDTO implements QuestionDTO {
     public static final QuestionType questionType = QuestionType.FillInTheBlanks;
     private final String id;
+    private final String language;
     public final String text;
     public final String hint;
 
-    public FillInTheBlanksQuestionDTO(String id, String text, String hint) {
+    public FillInTheBlanksQuestionDTO(String id, String language, String text, String hint) {
         if (id == null || id.isBlank()) {
             throw new IllegalArgumentException("id must not be blank or null");
+        }
+
+        if (language == null || language.isBlank()) {
+            throw new IllegalArgumentException("language must not be blank or null");
         }
 
         if (text == null || text.isBlank()) {
@@ -19,6 +24,7 @@ public final class FillInTheBlanksQuestionDTO implements QuestionDTO {
         }
 
         this.id = id;
+        this.language = language;
         this.text = text;
         this.hint = Objects.requireNonNullElse(hint, "");
     }
@@ -38,5 +44,9 @@ public final class FillInTheBlanksQuestionDTO implements QuestionDTO {
 
     public String getHint() {
         return hint;
+    }
+
+    public String getLanguage() {
+        return language;
     }
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/QuestionDTO.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/QuestionDTO.java
@@ -7,6 +7,7 @@ import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
 public sealed interface QuestionDTO permits FillInTheBlanksQuestionDTO {
     String getID();
     QuestionType getQuestionType();
+    String getLanguage();
 
     static QuestionDTO fromQuestion(Question question) {
         if (question == null) {
@@ -16,7 +17,12 @@ public sealed interface QuestionDTO permits FillInTheBlanksQuestionDTO {
         return switch (question.getQuestionType()) {
             case FillInTheBlanks -> {
                 var typedQuestion = (FillInTheBlanksQuestion)question;
-                yield new FillInTheBlanksQuestionDTO(typedQuestion.getID(), typedQuestion.questionText, typedQuestion.hint);
+                yield new FillInTheBlanksQuestionDTO(
+                    typedQuestion.getID(),
+                    typedQuestion.getLanguage(),
+                    typedQuestion.questionText,
+                    typedQuestion.hint
+                );
             }
         };
     }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestion.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestion.java
@@ -8,15 +8,20 @@ import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
 
 public final class FillInTheBlanksQuestion implements Question {
     private final String id;
+    private final String language;
     private final static QuestionType questionType = QuestionType.FillInTheBlanks;
 
     public final String questionText;
     public final String hint;
     public final String answer;
 
-    public FillInTheBlanksQuestion(String id, String questionText, String hint, String answer) {
+    public FillInTheBlanksQuestion(String id, String language, String questionText, String hint, String answer) {
         if (id == null || id.isBlank()) {
             throw new IllegalArgumentException("ID cannot be null or blank");
+        }
+
+        if (language == null || language.isBlank()) {
+            throw new IllegalArgumentException("Language cannot be null or blank");
         }
 
         if (questionText == null || questionText.isBlank()) {
@@ -32,6 +37,7 @@ public final class FillInTheBlanksQuestion implements Question {
         }
 
         this.id = id;
+        this.language = language;
         this.questionText = questionText;
         this.hint = hint;
         this.answer = answer;
@@ -45,6 +51,11 @@ public final class FillInTheBlanksQuestion implements Question {
     @Override
     public QuestionType getQuestionType() {
         return questionType;
+    }
+
+    @Override
+    public String getLanguage() {
+        return language;
     }
 
     @Override

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/Question.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/Question.java
@@ -6,5 +6,6 @@ import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.At
 public sealed interface Question permits FillInTheBlanksQuestion {
     String getID();
     QuestionType getQuestionType();
+    String getLanguage();
     AttemptResponse assessAttempt(AttemptRequest request);
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Exceptions/QuestionWithIDAlreadyExistsException.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Exceptions/QuestionWithIDAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package com.munetmo.lingetic.LanguageTestService.Exceptions;
+
+public class QuestionWithIDAlreadyExistsException extends RuntimeException {
+    public QuestionWithIDAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Repositories/QuestionRepository.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Repositories/QuestionRepository.java
@@ -2,10 +2,13 @@ package com.munetmo.lingetic.LanguageTestService.Repositories;
 
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.Question;
 import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionNotFoundException;
+import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionWithIDAlreadyExistsException;
 
 import java.util.List;
 
 public interface QuestionRepository {
     Question getQuestionByID(String id) throws QuestionNotFoundException;
     List<Question> getAllQuestions();
+    List<Question> getQuestionsByLanguage(String language);
+    void addQuestion(Question question) throws QuestionWithIDAlreadyExistsException;
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/UseCases/TakeRegularTestUseCase.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/UseCases/TakeRegularTestUseCase.java
@@ -14,6 +14,13 @@ public class TakeRegularTestUseCase {
         this.questionRepository = questionRepository;
     }
 
+    public List<QuestionDTO> execute(String language) {
+        return questionRepository.getQuestionsByLanguage(language).stream()
+            .limit(limit)
+            .map(QuestionDTO::fromQuestion)
+            .toList();
+    }
+
     public List<QuestionDTO> execute() {
         return questionRepository.getAllQuestions().stream()
             .limit(limit)

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/HTTP/QuestionsController.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/HTTP/QuestionsController.java
@@ -26,7 +26,7 @@ public class QuestionsController {
 
     @GetMapping
     public ResponseEntity<List<QuestionDTO>> getQuestions(@RequestParam String language) {
-        var questions = takeRegularTestUseCase.execute();
+        var questions = takeRegularTestUseCase.execute(language);
         return ResponseEntity.ok(questions);
     }
 

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/Repositories/InMemory/QuestionInMemoryRepository.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/Repositories/InMemory/QuestionInMemoryRepository.java
@@ -2,86 +2,48 @@ package com.munetmo.lingetic.LanguageTestService.infra.Repositories.InMemory;
 
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.Question;
 import com.munetmo.lingetic.LanguageTestService.Repositories.QuestionRepository;
-import com.munetmo.lingetic.LanguageTestService.Entities.Questions.FillInTheBlanksQuestion;
 import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionNotFoundException;
+import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionWithIDAlreadyExistsException;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class QuestionInMemoryRepository implements QuestionRepository {
-    private static final List<Question> QUESTIONS = List.of(
-            new FillInTheBlanksQuestion(
-                "1", 
-                "The cat ____ lazily on the windowsill.",
-                "straighten or extend one's body",
-                "stretched"
-            ),
-            new FillInTheBlanksQuestion(
-                "2",
-                "She ____ her coffee every morning.",
-                "to drink",
-                "drinks"
-            ),
-            new FillInTheBlanksQuestion(
-                "3",
-                "The children ____ in the park yesterday.",
-                "to have fun or recreation",
-                "played"
-            ),
-            new FillInTheBlanksQuestion(
-                "4",
-                "He ____ the piano beautifully.",
-                "to create music with an instrument",
-                "plays"
-            ),
-            new FillInTheBlanksQuestion(
-                "5",
-                "They ____ dinner at 7 PM.",
-                "to consume food",
-                "eat"
-            ),
-            new FillInTheBlanksQuestion(
-                "6",
-                "The birds ____ south for the winter.",
-                "to move through the air using wings",
-                "fly"
-            ),
-            new FillInTheBlanksQuestion(
-                "7",
-                "The teacher ____ the lesson clearly.",
-                "to give information about something",
-                "explains"
-            ),
-            new FillInTheBlanksQuestion(
-                "8",
-                "We ____ to the beach every summer.",
-                "to travel or move to a place",
-                "go"
-            ),
-            new FillInTheBlanksQuestion(
-                "9",
-                "The sun ____ in the east.",
-                "to come above the horizon",
-                "rises"
-            ),
-            new FillInTheBlanksQuestion(
-                "10",
-                "She ____ beautiful music on her violin.",
-                "to create pleasant sounds",
-                "makes"
-            )
-    );
+    private final Map<String, Question> questions;
+
+    public QuestionInMemoryRepository() {
+        questions = new HashMap<>();
+    }
 
     @Override
     public Question getQuestionByID(String id) throws QuestionNotFoundException {
-        var foundQuestion = QUESTIONS.stream().filter(q -> q.getID().equals(id)).findFirst().orElse(null);
-        if (foundQuestion == null) {
+        if (!questions.containsKey(id)) {
             throw new QuestionNotFoundException("Question with ID %s not found.".formatted(id));
         }
-        return foundQuestion;
+        return questions.get(id);
     }
 
     @Override
     public List<Question> getAllQuestions() {
-        return QUESTIONS;
+        return new ArrayList<>(questions.values());
+    }
+
+    @Override
+    public void addQuestion(Question question) throws QuestionWithIDAlreadyExistsException {
+        if (questions.containsKey(question.getID())) {
+            throw new QuestionWithIDAlreadyExistsException(
+                "Question with ID %s already exists.".formatted(question.getID())
+            );
+        }
+        questions.put(question.getID(), question);
+    }
+
+    @Override
+    public List<Question> getQuestionsByLanguage(String language) {
+        return questions.values().stream()
+            .filter(q -> q.getLanguage().equals(language))
+            .toList();
     }
 }

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/FillInTheBlanksQuestionDTOTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/FillInTheBlanksQuestionDTOTest.java
@@ -10,6 +10,7 @@ public class FillInTheBlanksQuestionDTOTest {
     void shouldCreateQuestionDTO() {
         FillInTheBlanksQuestionDTO question = new FillInTheBlanksQuestionDTO(
                 "q123",
+                "en",
                 "Fill in: ___",
                 "This is a hint");
 
@@ -22,35 +23,50 @@ public class FillInTheBlanksQuestionDTOTest {
     @Test
     void shouldThrowExceptionWhenIdIsNull() {
         var exception = assertThrows(IllegalArgumentException.class, () -> new FillInTheBlanksQuestionDTO(
-                null, "Fill in: ___", "This is a hint"));
+                null, "en", "Fill in: ___", "This is a hint"));
         assertTrue(exception.getMessage().contains("id"));
     }
 
     @Test
     void shouldThrowExceptionWhenIdIsBlank() {
         var exception = assertThrows(IllegalArgumentException.class, () -> new FillInTheBlanksQuestionDTO(
-                "", "Fill in: ___", "This is a hint"));
+                "", "en", "Fill in: ___", "This is a hint"));
         assertTrue(exception.getMessage().contains("id"));
     }
 
     @Test
     void shouldThrowExceptionWhenGetTextIsNull() {
         var exception = assertThrows(IllegalArgumentException.class, () -> new FillInTheBlanksQuestionDTO(
-                "q123", null, "This is a hint"));
+                "q123", "en", null, "This is a hint"));
         assertTrue(exception.getMessage().contains("text"));
     }
 
     @Test
     void shouldThrowExceptionWhenGetTextIsBlank() {
         var exception = assertThrows(IllegalArgumentException.class, () -> new FillInTheBlanksQuestionDTO(
-                "q123", "", "This is a hint"));
+                "q123", "en", "", "This is a hint"));
         assertTrue(exception.getMessage().contains("text"));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenLanguageIsNull() {
+        var exception = assertThrows(IllegalArgumentException.class, () -> new FillInTheBlanksQuestionDTO(
+                "q123", null, "Fill in: ___", "This is a hint"));
+        assertTrue(exception.getMessage().contains("language"));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenLanguageIsBlank() {
+        var exception = assertThrows(IllegalArgumentException.class, () -> new FillInTheBlanksQuestionDTO(
+                "q123", "", "Fill in: ___", "This is a hint"));
+        assertTrue(exception.getMessage().contains("language"));
     }
 
     @Test
     void shouldCreateQuestionDTOWithoutGetHint() {
         FillInTheBlanksQuestionDTO question = new FillInTheBlanksQuestionDTO(
                 "q123",
+                "en",
                 "Fill in: ___",
                 null);
 
@@ -64,6 +80,7 @@ public class FillInTheBlanksQuestionDTOTest {
     void shouldCreateQuestionDTOWithEmptyGetHint() {
         FillInTheBlanksQuestionDTO question = new FillInTheBlanksQuestionDTO(
                 "q123",
+                "en",
                 "Fill in: ___",
                 "");
 

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/QuestionDTOTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/QuestionDTOTest.java
@@ -10,7 +10,8 @@ class QuestionDTOTest {
     @Test
     void shouldConvertFillInTheBlanksQuestionToDTO() {
         FillInTheBlanksQuestion question = new FillInTheBlanksQuestion(
-            "q123", 
+            "q123",
+            "en",
             "Fill in: ___", 
             "This is a hint",
             "test answer"

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestionTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestionTest.java
@@ -13,13 +13,15 @@ class FillInTheBlanksQuestionTest {
     @Test
     void constructorShouldCreateValidObjectWithCorrectValues() {
         var id = "test-id";
+        var language = "en";
         var questionText = "Fill in the ___";
         var hint = "test hint";
         var answer = "blank";
 
-        FillInTheBlanksQuestion question = new FillInTheBlanksQuestion(id, questionText, hint, answer);
+        FillInTheBlanksQuestion question = new FillInTheBlanksQuestion(id, language, questionText, hint, answer);
 
         assertEquals(id, question.getID());
+        assertEquals(language, question.getLanguage());
         assertEquals(QuestionType.FillInTheBlanks, question.getQuestionType());
         assertEquals(questionText, question.questionText);
         assertEquals(hint, question.hint);
@@ -30,14 +32,14 @@ class FillInTheBlanksQuestionTest {
     @ValueSource(strings = {" ", "   ", "\t", "\n"})
     void constructorShouldThrowExceptionWhenIdIsInvalid(String id) {
         assertThrows(IllegalArgumentException.class, () ->
-            new FillInTheBlanksQuestion(id, "Fill in the ___", "hint", "answer")
+            new FillInTheBlanksQuestion(id, "en", "Fill in the ___", "hint", "answer")
         );
     }
 
     @Test
     void constructorShouldThrowExceptionWhenIdIsNull() {
         assertThrows(IllegalArgumentException.class, () ->
-            new FillInTheBlanksQuestion(null, "Fill in the ___", "hint", "answer")
+            new FillInTheBlanksQuestion(null, "en", "Fill in the ___", "hint", "answer")
         );
     }
 
@@ -45,14 +47,14 @@ class FillInTheBlanksQuestionTest {
     @ValueSource(strings = {"", " ", "   ", "\t", "\n", "No blank here", "Multiple___ ___blanks", "Wrong blank --"})
     void constructorShouldThrowExceptionWhenQuestionTextIsInvalid(String questionText) {
         assertThrows(IllegalArgumentException.class, () ->
-            new FillInTheBlanksQuestion("id", questionText, "hint", "answer")
+            new FillInTheBlanksQuestion("id", "en", questionText, "hint", "answer")
         );
     }
 
     @Test
     void constructorShouldThrowExceptionWhenQuestionTextIsNull() {
         assertThrows(IllegalArgumentException.class, () ->
-            new FillInTheBlanksQuestion("id", null, "hint", "answer")
+            new FillInTheBlanksQuestion("id", "en", null, "hint", "answer")
         );
     }
 
@@ -60,21 +62,36 @@ class FillInTheBlanksQuestionTest {
     @ValueSource(strings = {"", " ", "   ", "\t", "\n"})
     void constructorShouldThrowExceptionWhenAnswerIsInvalid(String answer) {
         assertThrows(IllegalArgumentException.class, () ->
-            new FillInTheBlanksQuestion("id", "Fill in the ___", "hint", answer)
+            new FillInTheBlanksQuestion("id", "en", "Fill in the ___", "hint", answer)
         );
     }
 
     @Test
     void constructorShouldThrowExceptionWhenAnswerIsNull() {
         assertThrows(IllegalArgumentException.class, () ->
-            new FillInTheBlanksQuestion("id", "Fill in the ___", "hint", null)
+            new FillInTheBlanksQuestion("id", "en", "Fill in the ___", "hint", null)
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {" ", "   ", "\t", "\n"})
+    void constructorShouldThrowExceptionWhenLanguageIsInvalid(String language) {
+        assertThrows(IllegalArgumentException.class, () ->
+            new FillInTheBlanksQuestion("id", language, "Fill in the ___", "hint", "answer")
+        );
+    }
+
+    @Test
+    void constructorShouldThrowExceptionWhenLanguageIsNull() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new FillInTheBlanksQuestion("id", null, "Fill in the ___", "hint", "answer")
         );
     }
 
     @Test
     void assessAttemptShouldReturnSuccessForCorrectAnswer() {
         var question = new FillInTheBlanksQuestion(
-            "id", "Fill in the ___", "hint", "correct"
+            "id", "en", "Fill in the ___", "hint", "correct"
         );
         var request = new FillInTheBlanksAttemptRequest(question.getID(), question.answer);
 
@@ -87,7 +104,7 @@ class FillInTheBlanksQuestionTest {
     @Test
     void assessAttemptShouldReturnFailureForIncorrectAnswer() {
         var question = new FillInTheBlanksQuestion(
-            "id", "Fill in the ___", "hint", "correct"
+            "id", "en", "Fill in the ___", "hint", "correct"
         );
         var request = new FillInTheBlanksAttemptRequest(question.getID(), "wrong");
 

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCaseTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCaseTest.java
@@ -6,6 +6,7 @@ import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.At
 import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
 import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionNotFoundException;
 import com.munetmo.lingetic.LanguageTestService.infra.Repositories.InMemory.QuestionInMemoryRepository;
+import com.munetmo.lingetic.LanguageTestService.Entities.Questions.FillInTheBlanksQuestion;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -13,11 +14,20 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class AttemptQuestionUseCaseTest {
     private AttemptQuestionUseCase attemptQuestionUseCase;
+    private QuestionInMemoryRepository questionRepository;
 
     @BeforeEach
     void setUp() {
-        var questionRepository = new QuestionInMemoryRepository();
+        questionRepository = new QuestionInMemoryRepository();
         attemptQuestionUseCase = new AttemptQuestionUseCase(questionRepository);
+
+        questionRepository.addQuestion(new FillInTheBlanksQuestion(
+            "1",
+            "en",
+            "The cat ____ lazily on the windowsill.",
+            "straighten or extend one's body",
+            "stretched"
+        ));
     }
 
     @Test

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/TakeRegularTestUseCaseTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/TakeRegularTestUseCaseTest.java
@@ -4,27 +4,74 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.munetmo.lingetic.LanguageTestService.DTOs.Question.QuestionDTO;
 import com.munetmo.lingetic.LanguageTestService.infra.Repositories.InMemory.QuestionInMemoryRepository;
+import com.munetmo.lingetic.LanguageTestService.Entities.Questions.FillInTheBlanksQuestion;
 
 class TakeRegularTestUseCaseTest {
     private TakeRegularTestUseCase useCase;
+    private QuestionInMemoryRepository repository;
 
     @BeforeEach
     void setUp() {
-        QuestionInMemoryRepository repository = new QuestionInMemoryRepository();
+        repository = new QuestionInMemoryRepository();
         useCase = new TakeRegularTestUseCase(repository);
     }
 
+    private void addTestQuestions(int count) {
+        IntStream.rangeClosed(1, count).forEach(i -> repository.addQuestion(new FillInTheBlanksQuestion(
+                String.valueOf(i),
+                "en",
+                "Question " + i + ": He ____ to school.",
+                "motion verb",
+                "walks"
+        )));
+    }
+
     @Test
-    void shouldReturnAllQuestionsAsQuestionDTOs() {
+    void shouldReturnAllQuestionsWhenLessThanLimit() {
+        int questionsCount = TakeRegularTestUseCase.limit - 5;
+        addTestQuestions(questionsCount);
+
         List<QuestionDTO> result = useCase.execute();
 
-        assertTrue(result.size() <= TakeRegularTestUseCase.limit);
+        assertEquals(questionsCount, result.size());
         assertTrue(result.stream().allMatch(Objects::nonNull));
+    }
+
+    @Test
+    void shouldReturnQuestionsUpToLimitWhenMoreQuestionsExist() {
+        int questionsCount = TakeRegularTestUseCase.limit + 5;
+        addTestQuestions(questionsCount);
+
+        List<QuestionDTO> result = useCase.execute();
+
+        assertEquals(TakeRegularTestUseCase.limit, result.size());
+        assertTrue(result.stream().allMatch(Objects::nonNull));
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenNoQuestionsExist() {
+        List<QuestionDTO> result = useCase.execute();
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void shouldOnlyReturnQuestionsInRequestedLanguage() {
+        repository.addQuestion(new FillInTheBlanksQuestion("1", "en", "He ____ to school.", "motion verb", "walks"));
+        repository.addQuestion(new FillInTheBlanksQuestion("2", "es", "El ____ a la escuela.", "verbo de movimiento", "camina"));
+        repository.addQuestion(new FillInTheBlanksQuestion("3", "en", "She ____ fast.", "motion verb", "runs"));
+        repository.addQuestion(new FillInTheBlanksQuestion("4", "fr", "Il ____ à l'école.", "verbe de mouvement", "marche"));
+
+        List<QuestionDTO> result = useCase.execute("en");
+
+        assertEquals(2, result.size());
+        assertTrue(result.stream().allMatch(q -> q.getLanguage().equals("en")));
     }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Added filtering by language for questions in the `TakeRegularTestUseCase`.

- Introduced `language` field in `FillInTheBlanksQuestion` and `FillInTheBlanksQuestionDTO`.

- Updated repositories to support language-based question retrieval and addition.

- Added new exception `QuestionWithIDAlreadyExistsException` for duplicate question handling.

- Enhanced test coverage for new functionality and validations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>FillInTheBlanksQuestionDTO.java</strong><dd><code>Added `language` field and validation to DTO</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/51/files#diff-fa213b6fcea598170beee82aacbd0950ae8777132b472697dac49c121e887ce6">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>QuestionDTO.java</strong><dd><code>Added `getLanguage` method and updated conversion logic</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/51/files#diff-b4f6d517766f87823fff5027e68bcd672c3e16ba706f87202ed475de7eee4eeb">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>FillInTheBlanksQuestion.java</strong><dd><code>Added `language` field and validation to entity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/51/files#diff-9d7d86a8c1cbe2e930918d9e5a4021a7c1d4930d95984dc745674893181140f3">+12/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Question.java</strong><dd><code>Added `getLanguage` method to interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/51/files#diff-a0e0605d676bd6e65c6af8054f1c9e9838989929823ebd9475e063388d873d0f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>QuestionRepository.java</strong><dd><code>Added methods for language-based retrieval and question addition</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/51/files#diff-78255af545c8812fb069c5bdfef2377c32dff887364e0adde53987da44ae09d7">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TakeRegularTestUseCase.java</strong><dd><code>Added execution logic for language-based filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/51/files#diff-572f192a7c115ca5a0e26ca31f1578afe9f28f391794233cf01295f3a33c4be3">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>QuestionsController.java</strong><dd><code>Updated controller to handle language parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/51/files#diff-c36dc4682e666603d6c2c01dc252f4c96ff6b4983613f5985e8e8fb5613e7bb2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>QuestionInMemoryRepository.java</strong><dd><code>Refactored repository to support dynamic question storage and </code><br><code>filtering</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/51/files#diff-cf743cff6036639351429427a97c9d2459d8f5c3480a16109d5d736f50833f0f">+29/-67</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Error handling</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>QuestionWithIDAlreadyExistsException.java</strong><dd><code>Added new exception for duplicate question IDs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/51/files#diff-5db1b0fdeb85ddbfd4d26399c38589aab940c195241561b1f7ea4f6fae18e5e7">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>FillInTheBlanksQuestionDTOTest.java</strong><dd><code>Added tests for `language` field in DTO</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/51/files#diff-5ba7be7435286726432203ffa1e026197c626b84f55b52a0266050595d0c3b04">+21/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>QuestionDTOTest.java</strong><dd><code>Updated tests for DTO conversion with `language`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/51/files#diff-a6903e4b0031d84c303aa4c979ef61300fe747c0a8edd8510272e4d2b6457ee9">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>FillInTheBlanksQuestionTest.java</strong><dd><code>Added tests for `language` field in entity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/51/files#diff-0a3416aadee18c0ed2c84823014f4921e4d5f6f02115bfda63a633e1d265a867">+26/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AttemptQuestionUseCaseTest.java</strong><dd><code>Updated tests to include questions with `language`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/51/files#diff-6564db7713f761ac261226011bd4890a7331c730ae57545f0ca164f5c2eadc79">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TakeRegularTestUseCaseTest.java</strong><dd><code>Added tests for language-based filtering in use case</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/51/files#diff-a6198b6ed08529c39d68e286f8a8517ca2237e510b1ac4a965e037d8a17a5c45">+50/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Questions now require a language selection, ensuring that submissions and retrievals are aligned with the chosen language.
  - You can now filter the question set by language for a more tailored quiz experience.
  
- **Chores**
  - Enhanced backend validations and dynamic question management improve overall system robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->