### PR TITLE
Add validation checks in QuestionsController.java

### DIFF
--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/HTTP/QuestionsController.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/HTTP/QuestionsController.java
@@ -25,13 +25,25 @@ public class QuestionsController {
     private AttemptQuestionUseCase attemptQuestionUseCase;
 
     @GetMapping
-    public ResponseEntity<List<QuestionDTO>> getQuestions(@RequestParam String language) {
+    public ResponseEntity<?> getQuestions(@RequestParam String language) {
+        if (language == null || language.isBlank()) {
+            return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body("Language parameter cannot be null or empty");
+        }
+
         var questions = takeRegularTestUseCase.execute(language);
         return ResponseEntity.ok(questions);
     }
 
     @PostMapping("/attempt")
     public ResponseEntity<?> attemptQuestion(@RequestBody AttemptRequest request) {
+        if (request == null) {
+            return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body("Attempt request cannot be null");
+        }
+
         try {
             var response = attemptQuestionUseCase.execute(request);
             return ResponseEntity.ok(response);


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added validation for null or empty `language` parameter in `getQuestions` method.

- Added validation for null `AttemptRequest` in `attemptQuestion` method.

- Improved error handling with meaningful HTTP responses.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>QuestionsController.java</strong><dd><code>Add input validation and error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/HTTP/QuestionsController.java

<li>Added validation for <code>language</code> parameter in <code>getQuestions</code>.<br> <li> Added validation for null <code>AttemptRequest</code> in <code>attemptQuestion</code>.<br> <li> Enhanced error handling with HTTP 400 responses for invalid inputs.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/52/files#diff-c36dc4682e666603d6c2c01dc252f4c96ff6b4983613f5985e8e8fb5613e7bb2">+13/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced validation on language test endpoints to ensure required inputs are provided.
  - Now provides clear and informative error messages when inputs are missing or invalid.
  - Improved response handling supports more flexible outcomes, offering a better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->