### PR TITLE
Make hint @Nullable

### DIFF
--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestion.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestion.java
@@ -5,6 +5,9 @@ import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests.Fil
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.AttemptResponse;
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.FillInTheBlanksAttemptResponse;
 import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
 
 public final class FillInTheBlanksQuestion implements Question {
     private final String id;
@@ -15,7 +18,7 @@ public final class FillInTheBlanksQuestion implements Question {
     public final String hint;
     public final String answer;
 
-    public FillInTheBlanksQuestion(String id, String language, String questionText, String hint, String answer) {
+    public FillInTheBlanksQuestion(String id, String language, String questionText, @Nullable String hint, String answer) {
         if (id.isBlank()) {
             throw new IllegalArgumentException("ID cannot be blank");
         }
@@ -39,7 +42,7 @@ public final class FillInTheBlanksQuestion implements Question {
         this.id = id;
         this.language = language;
         this.questionText = questionText;
-        this.hint = hint;
+        this.hint = Objects.requireNonNullElse(hint, "");
         this.answer = answer;
     }
 


### PR DESCRIPTION
### **User description**
There's a meaningful default for hint that should
be used when null is passed.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Marked `hint` parameter as `@Nullable` in constructor.

- Added default value handling for `hint` using `Objects.requireNonNullElse`.

- Improved null safety and ensured meaningful defaults for `hint`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FillInTheBlanksQuestion.java</strong><dd><code>Mark `hint` as nullable and add default handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestion.java

<li>Added <code>@Nullable</code> annotation to <code>hint</code> parameter.<br> <li> Used <code>Objects.requireNonNullElse</code> to provide default value for <code>hint</code>.<br> <li> Improved constructor validation for <code>hint</code>.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/54/files#diff-9d7d86a8c1cbe2e930918d9e5a4021a7c1d4930d95984dc745674893181140f3">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved behavior for fill-in-the-blanks questions by ensuring that if a hint isn’t provided, it now defaults to an empty value. This enhancement avoids display issues and delivers a more reliable, consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->