### PR TITLE
Remove circular dependency

### DIFF
--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Repositories/QuestionReviewRepository.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Repositories/QuestionReviewRepository.java
@@ -1,6 +1,7 @@
 package com.munetmo.lingetic.LanguageTestService.Repositories;
 
 import com.munetmo.lingetic.LanguageTestService.Entities.QuestionReview;
+import com.munetmo.lingetic.LanguageTestService.Entities.Questions.Question;
 
 import java.util.List;
 
@@ -9,5 +10,5 @@ public interface QuestionReviewRepository {
     List<QuestionReview> getAllReviews();
     void addReview(QuestionReview review);
     void update(QuestionReview review);
-    QuestionReview getReviewByQuestionIDOrCreate(String questionID);
+    QuestionReview getReviewForQuestionOrCreateNew(Question question);
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCase.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCase.java
@@ -20,7 +20,7 @@ public class AttemptQuestionUseCase {
         var question = questionRepository.getQuestionByID(request.getQuestionID());
         var response = question.assessAttempt(request);
         
-        var questionReview = questionReviewRepository.getReviewByQuestionIDOrCreate(request.getQuestionID());
+        var questionReview = questionReviewRepository.getReviewForQuestionOrCreateNew(question);
         questionReview.review(
             switch (response.getAttemptStatus()) {
                 case AttemptStatus.Success -> 5;

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/Beans.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/Beans.java
@@ -23,10 +23,8 @@ public class Beans {
     }
 
     @Bean
-    public QuestionReviewRepository questionReviewRepository(QuestionRepository questionRepository) {
-        var questionReviewRepository = new QuestionReviewInMemoryRepository();
-        questionReviewRepository.setQuestionRepository(questionRepository);
-        return questionReviewRepository;
+    public QuestionReviewRepository questionReviewRepository() {
+        return new QuestionReviewInMemoryRepository();
     }
 
     @Bean

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/TakeRegularTestUseCaseTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/TakeRegularTestUseCaseTest.java
@@ -24,7 +24,6 @@ class TakeRegularTestUseCaseTest {
     void setUp() {
         questionReviewRepository = new QuestionReviewInMemoryRepository();
         questionRepository = new QuestionInMemoryRepository(questionReviewRepository);
-        questionReviewRepository.setQuestionRepository(questionRepository);
         useCase = new TakeRegularTestUseCase(questionRepository, questionReviewRepository);
     }
 
@@ -50,7 +49,7 @@ class TakeRegularTestUseCaseTest {
                 break;
             }
 
-            var questionReview = questionReviewRepository.getReviewByQuestionIDOrCreate(question.getID());
+            var questionReview = questionReviewRepository.getReviewForQuestionOrCreateNew(question);
             questionReview.review(quality);
             questionReviewRepository.update(questionReview);
 
@@ -114,7 +113,7 @@ class TakeRegularTestUseCaseTest {
         addTestQuestions(TakeRegularTestUseCase.limit);
         var reviewedQuestion = new FillInTheBlanksQuestion("rq1", "en", "He ____ to school.", "motion verb", "walks");
         questionRepository.addQuestion(reviewedQuestion);
-        var questionReview = questionReviewRepository.getReviewByQuestionIDOrCreate(reviewedQuestion.getID());
+        var questionReview = questionReviewRepository.getReviewForQuestionOrCreateNew(reviewedQuestion);
         questionReview.review(1);
         questionReviewRepository.update(questionReview);
 


### PR DESCRIPTION
### **User description**
The circular dependency existed between Question
and QuestionReview repositories.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Removed circular dependency between `Question` and `QuestionReviewRepository`.

- Refactored `getReviewByQuestionIDOrCreate` to `getReviewForQuestionOrCreateNew`.

- Updated tests to reflect the new method signature and logic.

- Simplified `QuestionReviewInMemoryRepository` by removing unnecessary dependencies.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>QuestionReviewRepository.java</strong><dd><code>Refactored QuestionReviewRepository method signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Repositories/QuestionReviewRepository.java

<li>Added <code>Question</code> import.<br> <li> Renamed method <code>getReviewByQuestionIDOrCreate</code> to <br><code>getReviewForQuestionOrCreateNew</code>.<br> <li> Updated method signature to accept <code>Question</code> instead of <code>questionID</code>.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/59/files#diff-0e28bf5921aad22d43ec575c10e54b8a7b92003827b652f8b8b442a942f2f065">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AttemptQuestionUseCase.java</strong><dd><code>Updated AttemptQuestionUseCase to use refactored method</code>&nbsp; &nbsp; </dd></summary>
<hr>

lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCase.java

<li>Updated call to <code>getReviewByQuestionIDOrCreate</code> to use <br><code>getReviewForQuestionOrCreateNew</code>.<br> <li> Passed <code>Question</code> object instead of <code>questionID</code>.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/59/files#diff-b9cdd01806c5f1a01ec65a1cca563180c208e58850957f2309637118b7a606c3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>QuestionReviewInMemoryRepository.java</strong><dd><code>Refactored QuestionReviewInMemoryRepository to remove dependencies</code></dd></summary>
<hr>

lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/Repositories/InMemory/QuestionReviewInMemoryRepository.java

<li>Removed dependency on <code>QuestionRepository</code>.<br> <li> Refactored <code>getReviewByQuestionIDOrCreate</code> to <br><code>getReviewForQuestionOrCreateNew</code>.<br> <li> Simplified logic for creating new <code>QuestionReview</code>.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/59/files#diff-01e53b3fbd94291139029618e0d6fedafe4bcdae1f0599f98951152ccebda0b9">+10/-30</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Beans.java</strong><dd><code>Simplified QuestionReviewRepository bean configuration</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/Beans.java

<li>Removed dependency injection of <code>QuestionRepository</code> into <br><code>QuestionReviewRepository</code>.<br> <li> Simplified <code>questionReviewRepository</code> bean creation.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/59/files#diff-4f9112c6797c4d53531f0cb3f81b6ef2e0945296bb0c287f9fd3c30c9e7308da">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AttemptQuestionUseCaseTest.java</strong><dd><code>Updated AttemptQuestionUseCaseTest for refactored method</code>&nbsp; </dd></summary>
<hr>

lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCaseTest.java

<li>Updated tests to use <code>getReviewForQuestionOrCreateNew</code>.<br> <li> Adjusted test setup to remove unnecessary repository dependencies.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/59/files#diff-6564db7713f761ac261226011bd4890a7331c730ae57545f0ca164f5c2eadc79">+18/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TakeRegularTestUseCaseTest.java</strong><dd><code>Updated TakeRegularTestUseCaseTest for refactored method</code>&nbsp; </dd></summary>
<hr>

lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/TakeRegularTestUseCaseTest.java

<li>Updated tests to use <code>getReviewForQuestionOrCreateNew</code>.<br> <li> Adjusted test setup to remove unnecessary repository dependencies.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/59/files#diff-a6198b6ed08529c39d68e286f8a8517ca2237e510b1ac4a965e037d8a17a5c45">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the process for retrieving and creating question reviews by using complete question objects instead of identifiers.
  - Simplified repository initialization by removing redundant dependencies to ensure a more streamlined, efficient workflow.

- **Tests**
  - Updated test cases to directly use new question objects, aligning them with the enhanced review retrieval approach for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->