### PR TITLE
Use LanguageModels to compare user input and answer

### DIFF
--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/LanguageModels/DummyLanguageModel.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/LanguageModels/DummyLanguageModel.java
@@ -1,0 +1,13 @@
+package com.munetmo.lingetic.LanguageTestService.Entities.LanguageModels;
+
+public final class DummyLanguageModel implements LanguageModel {
+    @Override
+    public String getLanguage() {
+        return "dummy";
+    }
+
+    @Override
+    public boolean areEquivalent(String s1, String s2) {
+        return s1.equals(s2);
+    }
+}

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/LanguageModels/EnglishLanguageModel.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/LanguageModels/EnglishLanguageModel.java
@@ -1,0 +1,31 @@
+package com.munetmo.lingetic.LanguageTestService.Entities.LanguageModels;
+
+import java.util.Arrays;
+import java.util.Locale;
+
+public final class EnglishLanguageModel implements LanguageModel {
+    @Override
+    public String getLanguage() {
+        return "english";
+    }
+
+    @Override
+    public boolean areEquivalent(String s1, String s2) {
+        var normalized1 = normalizeString(s1);
+        var normalized2 = normalizeString(s2);
+
+        return normalized1.equals(normalized2);
+    }
+
+    private String normalizeString(String input) {
+        var words = input.split("\\s+");
+        var normalizedWords = Arrays.stream(words)
+                .map(w -> w.trim().toLowerCase(Locale.ENGLISH))
+                .map(w -> w.replaceAll("^[^a-z0-9]+|[^a-z0-9]+$", ""))
+                .filter(w -> !w.isBlank());
+
+        var normalized = String.join(" ", normalizedWords.toList());
+        
+        return normalized;
+    }
+}

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/LanguageModels/LanguageModel.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/LanguageModels/LanguageModel.java
@@ -1,0 +1,16 @@
+package com.munetmo.lingetic.LanguageTestService.Entities.LanguageModels;
+
+import java.util.Map;
+
+public sealed interface LanguageModel permits DummyLanguageModel, EnglishLanguageModel {
+    String getLanguage();
+    boolean areEquivalent(String s1, String s2);
+
+    public static LanguageModel getLanguageModel(String language) {
+        var models = Map.of(
+            "english", (LanguageModel) new EnglishLanguageModel()
+        );
+
+        return models.getOrDefault(language, new DummyLanguageModel());
+    }
+}

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestion.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestion.java
@@ -5,6 +5,7 @@ import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests.Fil
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.AttemptResponse;
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.FillInTheBlanksAttemptResponse;
 import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
+import com.munetmo.lingetic.LanguageTestService.Entities.LanguageModels.LanguageModel;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Objects;
@@ -67,8 +68,13 @@ public final class FillInTheBlanksQuestion implements Question {
             throw new IllegalArgumentException("Invalid request type");
         }
 
+        var areEquivalent = LanguageModel.getLanguageModel(language).areEquivalent(
+            typedRequest.getUserResponse(),
+            answer
+        );
+
         return new FillInTheBlanksAttemptResponse(
-            typedRequest.getUserResponse().equals(answer) ? AttemptStatus.Success : AttemptStatus.Failure,
+            areEquivalent ? AttemptStatus.Success : AttemptStatus.Failure,
             answer
         );
     }

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/LanguageModels/EnglishLanguageModelTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/LanguageModels/EnglishLanguageModelTest.java
@@ -1,0 +1,69 @@
+package com.munetmo.lingetic.LanguageTestService.Entities.LanguageModels;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EnglishLanguageModelTest {
+    private EnglishLanguageModel model;
+
+    @BeforeEach
+    void setUp() {
+        model = new EnglishLanguageModel();
+    }
+
+    @Test
+    void getLanguageShouldReturnEnglish() {
+        assertEquals("english", model.getLanguage());
+    }
+
+    @Test
+    void areEquivalentShouldMatchIdenticalStrings() {
+        assertTrue(model.areEquivalent("hello", "hello"));
+        assertFalse(model.areEquivalent("hello", "world"));
+    }
+
+    @Test
+    void areEquivalentShouldIgnoreCase() {
+        assertTrue(model.areEquivalent("Hello", "hello"));
+        assertTrue(model.areEquivalent("HELLO", "hello"));
+        assertTrue(model.areEquivalent("HeLLo", "hEllO"));
+    }
+
+    @Test
+    void areEquivalentShouldIgnoreLeadingAndTrailingWhitespace() {
+        assertTrue(model.areEquivalent("hello ", "hello"));
+        assertTrue(model.areEquivalent(" hello", "hello "));
+        assertTrue(model.areEquivalent("  hello  ", "hello"));
+    }
+
+    @Test
+    void areEquivalentShouldWorkWithMultipleWords() {
+        assertTrue(model.areEquivalent("hello   world", "hello world"));
+        assertTrue(model.areEquivalent("hello\tworld", "hello world"));
+        assertTrue(model.areEquivalent("hello\nworld", "hello world"));
+        assertTrue(model.areEquivalent("Hello, world!", "hello world"));
+        assertFalse(model.areEquivalent("hello world", "goodbye world!"));
+    }
+
+    @Test
+    void areEquivalentShouldHandleEmptyStrings() {
+        assertTrue(model.areEquivalent("", ""));
+        assertTrue(model.areEquivalent(" ", " "));
+        assertTrue(model.areEquivalent(" ", ""));
+    }
+
+    @Test
+    void areEquivalentShouldIgnoreLeadingTrailingAndIntraWordPunctuation() {
+        assertTrue(model.areEquivalent("hello!", "hello!"));
+        assertTrue(model.areEquivalent("hello!", "hello"));
+        assertTrue(model.areEquivalent("hello, world", "hello world"));
+        assertFalse(model.areEquivalent("I'm", "Im"));
+    }
+
+    @Test
+    void areEquivalentShouldHandleNumbers() {
+        assertTrue(model.areEquivalent("1234", "  1234 "));
+    }
+}


### PR DESCRIPTION
### **User description**
* Introduce the concept of Language Models
* Add a dummy and an English language model


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduced a `LanguageModel` interface with implementations for dummy and English models.

- Added normalization logic in `EnglishLanguageModel` for string comparison.

- Integrated `LanguageModel` into `FillInTheBlanksQuestion` for user response assessment.

- Created comprehensive unit tests for `EnglishLanguageModel`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DummyLanguageModel.java</strong><dd><code>Add DummyLanguageModel implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/LanguageModels/DummyLanguageModel.java

<li>Added a <code>DummyLanguageModel</code> implementation.<br> <li> Implements <code>LanguageModel</code> interface with basic equivalence logic.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/61/files#diff-72f09243d58880caf7ce036a3d7f134dbb04735bede770f70334ba26f5d364e8">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EnglishLanguageModel.java</strong><dd><code>Add EnglishLanguageModel with normalization logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/LanguageModels/EnglishLanguageModel.java

<li>Added <code>EnglishLanguageModel</code> implementation.<br> <li> Introduced string normalization for equivalence checks.<br> <li> Handles case, whitespace, punctuation, and numbers.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/61/files#diff-47882cad599a75aa5b6dcc2429a919d3758d4801e0d6d2ce81f2332dbaed32c9">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LanguageModel.java</strong><dd><code>Define LanguageModel interface and factory method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/LanguageModels/LanguageModel.java

<li>Defined <code>LanguageModel</code> interface.<br> <li> Added static method to retrieve language-specific models.<br> <li> Supports <code>DummyLanguageModel</code> and <code>EnglishLanguageModel</code>.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/61/files#diff-1b767c3a07f514030a017ea4a474414b983a74fde3be1fce1c62734e9285e165">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FillInTheBlanksQuestion.java</strong><dd><code>Integrate LanguageModel into FillInTheBlanksQuestion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestion.java

<li>Integrated <code>LanguageModel</code> for user response assessment.<br> <li> Replaced direct string comparison with model-based equivalence.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/61/files#diff-9d7d86a8c1cbe2e930918d9e5a4021a7c1d4930d95984dc745674893181140f3">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EnglishLanguageModelTest.java</strong><dd><code>Add unit tests for EnglishLanguageModel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/LanguageModels/EnglishLanguageModelTest.java

<li>Added unit tests for <code>EnglishLanguageModel</code>.<br> <li> Tested normalization logic for various cases.<br> <li> Validated equivalence checks for strings, punctuation, and numbers.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/61/files#diff-fd70ea4d09e174a3847f525243d86e0c24f2c6ca1a5f261e31b129a6577833a9">+69/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the evaluation of fill-in-the-blanks responses with a language-aware answer checking system. This update provides more flexibility by tolerating variations in case, punctuation, and extra spaces, ensuring your answers are more accurately assessed.

- **Tests**
  - Introduced comprehensive tests to validate the improved answer matching, ensuring reliable and robust feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->