### PR TITLE
Use enum to denote languages in the backend

### DIFF
--- a/lingetic-nextjs-frontend/app/languages/page.tsx
+++ b/lingetic-nextjs-frontend/app/languages/page.tsx
@@ -2,22 +2,15 @@ import LanguageCard from "../components/LanguageCard";
 
 const languages = [
   {
-    id: "turkish",
-    name: "Turkish",
-    description: "Learn Turkish, the language of Turkey and Northern Cyprus.",
+    id: "English",
+    name: "English",
+    description: "Learn English, the most widely spoken language in the world.",
     image: undefined,
   },
   {
-    id: "spanish",
-    name: "Spanish",
-    description: "Learn Spanish, one of the world's most spoken languages.",
-    image: undefined,
-  },
-  {
-    id: "finnish",
-    name: "Finnish",
-    description:
-      "Learn Finnish, the language of Finland and its unique culture.",
+    id: "DummyLanguage",
+    name: "Random",
+    description: "Hmmm..",
     image: undefined,
   },
 ];

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/FillInTheBlanksQuestionDTO.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/FillInTheBlanksQuestionDTO.java
@@ -1,5 +1,6 @@
 package com.munetmo.lingetic.LanguageTestService.DTOs.Question;
 
+import com.munetmo.lingetic.LanguageTestService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
 import org.jspecify.annotations.Nullable;
 
@@ -8,17 +9,13 @@ import java.util.Objects;
 public final class FillInTheBlanksQuestionDTO implements QuestionDTO {
     public static final QuestionType questionType = QuestionType.FillInTheBlanks;
     private final String id;
-    private final String language;
+    private final Language language;
     public final String text;
     public final String hint;
 
-    public FillInTheBlanksQuestionDTO(String id, String language, String text, @Nullable String hint) {
+    public FillInTheBlanksQuestionDTO(String id, Language language, String text, @Nullable String hint) {
         if (id.isBlank()) {
             throw new IllegalArgumentException("id must not be blank");
-        }
-
-        if (language.isBlank()) {
-            throw new IllegalArgumentException("language must not be blank");
         }
 
         if (text.isBlank()) {
@@ -50,7 +47,7 @@ public final class FillInTheBlanksQuestionDTO implements QuestionDTO {
     }
 
     @Override
-    public String getLanguage() {
+    public Language getLanguage() {
         return language;
     }
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/QuestionDTO.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/QuestionDTO.java
@@ -1,5 +1,6 @@
 package com.munetmo.lingetic.LanguageTestService.DTOs.Question;
 
+import com.munetmo.lingetic.LanguageTestService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.FillInTheBlanksQuestion;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.Question;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
@@ -7,7 +8,7 @@ import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
 public sealed interface QuestionDTO permits FillInTheBlanksQuestionDTO {
     String getID();
     QuestionType getQuestionType();
-    String getLanguage();
+    Language getLanguage();
 
     static QuestionDTO fromQuestion(Question question) {
         return switch (question.getQuestionType()) {

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Language.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Language.java
@@ -1,0 +1,6 @@
+package com.munetmo.lingetic.LanguageTestService.Entities;
+
+public enum Language {
+    DummyLanguage,
+    English
+}

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/LanguageModels/DummyLanguageModel.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/LanguageModels/DummyLanguageModel.java
@@ -1,9 +1,11 @@
 package com.munetmo.lingetic.LanguageTestService.Entities.LanguageModels;
 
+import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+
 public final class DummyLanguageModel implements LanguageModel {
     @Override
-    public String getLanguage() {
-        return "dummy";
+    public Language getLanguage() {
+        return Language.DummyLanguage;
     }
 
     @Override

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/LanguageModels/EnglishLanguageModel.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/LanguageModels/EnglishLanguageModel.java
@@ -1,12 +1,14 @@
 package com.munetmo.lingetic.LanguageTestService.Entities.LanguageModels;
 
+import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+
 import java.util.Arrays;
 import java.util.Locale;
 
 public final class EnglishLanguageModel implements LanguageModel {
     @Override
-    public String getLanguage() {
-        return "english";
+    public Language getLanguage() {
+        return Language.English;
     }
 
     @Override

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/LanguageModels/LanguageModel.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/LanguageModels/LanguageModel.java
@@ -1,16 +1,20 @@
 package com.munetmo.lingetic.LanguageTestService.Entities.LanguageModels;
 
+import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+
+import java.util.Collections;
 import java.util.Map;
 
 public sealed interface LanguageModel permits DummyLanguageModel, EnglishLanguageModel {
-    String getLanguage();
+    Language getLanguage();
     boolean areEquivalent(String s1, String s2);
 
-    public static LanguageModel getLanguageModel(String language) {
-        var models = Map.of(
-            "english", (LanguageModel) new EnglishLanguageModel()
-        );
+    static final DummyLanguageModel dummyLanguageModelInstance = new DummyLanguageModel();
+    static final Map<Language, LanguageModel> languageModelInstances = Collections.unmodifiableMap(Map.of(
+        Language.English, new EnglishLanguageModel()
+    ));
 
-        return models.getOrDefault(language, new DummyLanguageModel());
+    public static LanguageModel getLanguageModel(Language language) {
+        return languageModelInstances.getOrDefault(language, dummyLanguageModelInstance);
     }
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/QuestionReview.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/QuestionReview.java
@@ -10,22 +10,19 @@ public class QuestionReview {
 
     public final String id;
     public final String questionID;
-    public final String language;
+    public final Language language;
 
     private int repetitions;
     private double easeFactor;
     private int interval;
     private Instant nextReviewInstant;
 
-    public QuestionReview(String id, String questionID, String language) {
+    public QuestionReview(String id, String questionID, Language language) {
         if (id.isBlank()) {
             throw new IllegalArgumentException("id cannot be blank");
         }
         if (questionID.isBlank()) {
             throw new IllegalArgumentException("questionID cannot be blank");
-        }
-        if (language.isBlank()) {
-            throw new IllegalArgumentException("language cannot be blank");
         }
 
         this.id = id;

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestion.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestion.java
@@ -5,6 +5,7 @@ import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests.Fil
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.AttemptResponse;
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.FillInTheBlanksAttemptResponse;
 import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
+import com.munetmo.lingetic.LanguageTestService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.LanguageModels.LanguageModel;
 import org.jspecify.annotations.Nullable;
 
@@ -12,20 +13,16 @@ import java.util.Objects;
 
 public final class FillInTheBlanksQuestion implements Question {
     private final String id;
-    private final String language;
+    private final Language language;
     private final static QuestionType questionType = QuestionType.FillInTheBlanks;
 
     public final String questionText;
     public final String hint;
     public final String answer;
 
-    public FillInTheBlanksQuestion(String id, String language, String questionText, @Nullable String hint, String answer) {
+    public FillInTheBlanksQuestion(String id, Language language, String questionText, @Nullable String hint, String answer) {
         if (id.isBlank()) {
             throw new IllegalArgumentException("ID cannot be blank");
-        }
-
-        if (language.isBlank()) {
-            throw new IllegalArgumentException("Language cannot be blank");
         }
 
         if (questionText.isBlank()) {
@@ -58,7 +55,7 @@ public final class FillInTheBlanksQuestion implements Question {
     }
 
     @Override
-    public String getLanguage() {
+    public Language getLanguage() {
         return language;
     }
 

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/Question.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/Question.java
@@ -2,10 +2,11 @@ package com.munetmo.lingetic.LanguageTestService.Entities.Questions;
 
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests.AttemptRequest;
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.AttemptResponse;
+import com.munetmo.lingetic.LanguageTestService.Entities.Language;
 
 public sealed interface Question permits FillInTheBlanksQuestion {
     String getID();
     QuestionType getQuestionType();
-    String getLanguage();
+    Language getLanguage();
     AttemptResponse assessAttempt(AttemptRequest request);
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Repositories/QuestionRepository.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Repositories/QuestionRepository.java
@@ -1,5 +1,6 @@
 package com.munetmo.lingetic.LanguageTestService.Repositories;
 
+import com.munetmo.lingetic.LanguageTestService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.Question;
 import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionNotFoundException;
 import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionWithIDAlreadyExistsException;
@@ -9,7 +10,7 @@ import java.util.List;
 public interface QuestionRepository {
     Question getQuestionByID(String id) throws QuestionNotFoundException;
     List<Question> getAllQuestions();
-    List<Question> getQuestionsByLanguage(String language);
+    List<Question> getQuestionsByLanguage(Language language);
     void addQuestion(Question question) throws QuestionWithIDAlreadyExistsException;
-    List<Question> getUnreviewedQuestions(String language, int limit);
+    List<Question> getUnreviewedQuestions(Language language, int limit);
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Repositories/QuestionReviewRepository.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Repositories/QuestionReviewRepository.java
@@ -1,12 +1,13 @@
 package com.munetmo.lingetic.LanguageTestService.Repositories;
 
+import com.munetmo.lingetic.LanguageTestService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.QuestionReview;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.Question;
 
 import java.util.List;
 
 public interface QuestionReviewRepository {
-    List<QuestionReview> getTopQuestionsToReview(String language, int limit);
+    List<QuestionReview> getTopQuestionsToReview(Language language, int limit);
     List<QuestionReview> getAllReviews();
     void addReview(QuestionReview review);
     void update(QuestionReview review);

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/UseCases/TakeRegularTestUseCase.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/UseCases/TakeRegularTestUseCase.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.munetmo.lingetic.LanguageTestService.DTOs.Question.*;
+import com.munetmo.lingetic.LanguageTestService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Repositories.QuestionRepository;
 import com.munetmo.lingetic.LanguageTestService.Repositories.QuestionReviewRepository;
 
@@ -22,7 +23,7 @@ public class TakeRegularTestUseCase {
         this.questionReviewRepository = questionReviewRepository;
     }
 
-    public List<QuestionDTO> execute(String language) {
+    public List<QuestionDTO> execute(Language language) {
         var now = Instant.now();
 
         var questionReviews = questionReviewRepository.getTopQuestionsToReview(language, limit);

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/HTTP/QuestionsController.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/HTTP/QuestionsController.java
@@ -1,6 +1,7 @@
 package com.munetmo.lingetic.LanguageTestService.infra.HTTP;
 
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests.AttemptRequest;
+import com.munetmo.lingetic.LanguageTestService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,7 +29,16 @@ public class QuestionsController {
                 .body("Language parameter cannot be null or empty");
         }
 
-        var questions = takeRegularTestUseCase.execute(language);
+        Language languageEnum;
+        try {
+            languageEnum = Language.valueOf(language);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body("Invalid language: " + language);
+        }
+
+        var questions = takeRegularTestUseCase.execute(languageEnum);
         return ResponseEntity.ok(questions);
     }
 

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/Repositories/InMemory/QuestionInMemoryRepository.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/Repositories/InMemory/QuestionInMemoryRepository.java
@@ -1,5 +1,6 @@
 package com.munetmo.lingetic.LanguageTestService.infra.Repositories.InMemory;
 
+import com.munetmo.lingetic.LanguageTestService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.Question;
 import com.munetmo.lingetic.LanguageTestService.Repositories.QuestionRepository;
 import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionNotFoundException;
@@ -44,14 +45,14 @@ public class QuestionInMemoryRepository implements QuestionRepository {
     }
 
     @Override
-    public List<Question> getQuestionsByLanguage(String language) {
+    public List<Question> getQuestionsByLanguage(Language language) {
         return questions.values().stream()
             .filter(q -> q.getLanguage().equals(language))
             .toList();
     }
 
     @Override
-    public List<Question> getUnreviewedQuestions(String language, int limit) {
+    public List<Question> getUnreviewedQuestions(Language language, int limit) {
         var reviewedQuestions = questionReviewRepository.getAllReviews();
         return getQuestionsByLanguage(language).stream()
             .filter(q -> reviewedQuestions.stream().noneMatch(r -> r.questionID.equals(q.getID())))

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/Repositories/InMemory/QuestionReviewInMemoryRepository.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/Repositories/InMemory/QuestionReviewInMemoryRepository.java
@@ -1,5 +1,6 @@
 package com.munetmo.lingetic.LanguageTestService.infra.Repositories.InMemory;
 
+import com.munetmo.lingetic.LanguageTestService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.QuestionReview;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.Question;
 import com.munetmo.lingetic.LanguageTestService.Repositories.QuestionReviewRepository;
@@ -14,7 +15,7 @@ public class QuestionReviewInMemoryRepository implements QuestionReviewRepositor
     }
 
     @Override
-    public List<QuestionReview> getTopQuestionsToReview(String language, int limit) {
+    public List<QuestionReview> getTopQuestionsToReview(Language language, int limit) {
         var questionReviews = reviews.stream()
             .filter(review -> review.language.equals(language))
             .sorted(Comparator.comparing(QuestionReview::getNextReviewInstant))

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/FillInTheBlanksQuestionDTOTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/FillInTheBlanksQuestionDTOTest.java
@@ -1,5 +1,6 @@
 package com.munetmo.lingetic.LanguageTestService.DTOs.Question;
 
+import com.munetmo.lingetic.LanguageTestService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
@@ -10,7 +11,7 @@ public class FillInTheBlanksQuestionDTOTest {
     void shouldCreateQuestionDTO() {
         FillInTheBlanksQuestionDTO question = new FillInTheBlanksQuestionDTO(
                 "q123",
-                "en",
+                Language.English,
                 "Fill in: ___",
                 "This is a hint");
 
@@ -23,7 +24,7 @@ public class FillInTheBlanksQuestionDTOTest {
     @Test
     void shouldThrowExceptionWhenIdIsBlank() {
         var exception = assertThrows(IllegalArgumentException.class, () -> new FillInTheBlanksQuestionDTO(
-                "", "en", "Fill in: ___", "This is a hint"));
+                "", Language.English, "Fill in: ___", "This is a hint"));
         assertNotNull(exception.getMessage());
         assertTrue(exception.getMessage().contains("id"));
     }
@@ -31,24 +32,16 @@ public class FillInTheBlanksQuestionDTOTest {
     @Test
     void shouldThrowExceptionWhenGetTextIsBlank() {
         var exception = assertThrows(IllegalArgumentException.class, () -> new FillInTheBlanksQuestionDTO(
-                "q123", "en", "", "This is a hint"));
+                "q123", Language.English, "", "This is a hint"));
         assertNotNull(exception.getMessage());
         assertTrue(exception.getMessage().contains("text"));
     }
-
-   @Test
-   void shouldThrowExceptionWhenLanguageIsBlank() {
-        var exception = assertThrows(IllegalArgumentException.class, () -> new FillInTheBlanksQuestionDTO(
-                "q123", "", "Fill in: ___", "This is a hint"));
-        assertNotNull(exception.getMessage());
-        assertTrue(exception.getMessage().contains("language"));
-   }
 
     @Test
     void shouldCreateQuestionDTOWithoutGetHint() {
         FillInTheBlanksQuestionDTO question = new FillInTheBlanksQuestionDTO(
                 "q123",
-                "en",
+                Language.English,
                 "Fill in: ___",
                 null);
 
@@ -62,7 +55,7 @@ public class FillInTheBlanksQuestionDTOTest {
     void shouldCreateQuestionDTOWithEmptyGetHint() {
         FillInTheBlanksQuestionDTO question = new FillInTheBlanksQuestionDTO(
                 "q123",
-                "en",
+                Language.English,
                 "Fill in: ___",
                 "");
 

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/QuestionDTOTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/QuestionDTOTest.java
@@ -1,5 +1,6 @@
 package com.munetmo.lingetic.LanguageTestService.DTOs.Question;
 
+import com.munetmo.lingetic.LanguageTestService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.FillInTheBlanksQuestion;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
 import org.junit.jupiter.api.Test;
@@ -11,7 +12,7 @@ class QuestionDTOTest {
     void shouldConvertFillInTheBlanksQuestionToDTO() {
         FillInTheBlanksQuestion question = new FillInTheBlanksQuestion(
             "q123",
-            "en",
+            Language.English,
             "Fill in: ___", 
             "This is a hint",
             "test answer"

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/LanguageModels/EnglishLanguageModelTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/LanguageModels/EnglishLanguageModelTest.java
@@ -1,5 +1,6 @@
 package com.munetmo.lingetic.LanguageTestService.Entities.LanguageModels;
 
+import com.munetmo.lingetic.LanguageTestService.Entities.Language;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +16,7 @@ class EnglishLanguageModelTest {
 
     @Test
     void getLanguageShouldReturnEnglish() {
-        assertEquals("english", model.getLanguage());
+        assertEquals(Language.English, model.getLanguage());
     }
 
     @Test

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/QuestionReviewTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/QuestionReviewTest.java
@@ -12,7 +12,7 @@ class QuestionReviewTest {
     void constructorShouldCreateValidInstance() {
         String id = "testId";
         String questionId = "testQuestionId";
-        String language = "en";
+        Language language = Language.English;
         
         var question = new QuestionReview(id, questionId, language);
         
@@ -24,24 +24,18 @@ class QuestionReviewTest {
     @Test
     void constructorShouldThrowExceptionForBlankId() {
         assertThrows(IllegalArgumentException.class, 
-            () -> new QuestionReview(" ", "questionId", "en"));
+            () -> new QuestionReview(" ", "questionId", Language.English));
     }
 
     @Test
     void constructorShouldThrowExceptionForBlankQuestionId() {
         assertThrows(IllegalArgumentException.class, 
-            () -> new QuestionReview("id", "", "en"));
-    }
-
-    @Test
-    void constructorShouldThrowExceptionForBlankLanguage() {
-        assertThrows(IllegalArgumentException.class, 
-            () -> new QuestionReview("id", "questionId", "    "));
+            () -> new QuestionReview("id", "", Language.English));
     }
 
     @Test
     void lowQualityShouldSetNextReviewInstantToARecentInstant() {
-        var question = new QuestionReview("id2", "qid2", "en");
+        var question = new QuestionReview("id2", "qid2", Language.English);
         Instant before = Instant.now();
 
         question.review(2);
@@ -54,7 +48,7 @@ class QuestionReviewTest {
 
     @Test
     void highQualityShouldSetNextReviewInstantToADistantInstant() {
-        var question = new QuestionReview("id3", "qid3", "en");
+        var question = new QuestionReview("id3", "qid3", Language.English);
         Instant before = Instant.now();
 
         question.review(5);
@@ -66,7 +60,7 @@ class QuestionReviewTest {
 
     @Test
     void invalidQualityShouldThrowException() {
-        var question = new QuestionReview("id4", "qid4", "en");
+        var question = new QuestionReview("id4", "qid4", Language.English);
 
         assertThrows(IllegalArgumentException.class, () -> question.review(-1));
         assertThrows(IllegalArgumentException.class, () -> question.review(6));

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestionTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestionTest.java
@@ -3,6 +3,7 @@ package com.munetmo.lingetic.LanguageTestService.Entities.Questions;
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests.FillInTheBlanksAttemptRequest;
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.FillInTheBlanksAttemptResponse;
 import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
+import com.munetmo.lingetic.LanguageTestService.Entities.Language;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -13,7 +14,7 @@ class FillInTheBlanksQuestionTest {
     @Test
     void constructorShouldCreateValidObjectWithCorrectValues() {
         var id = "test-id";
-        var language = "en";
+        var language = Language.English;
         var questionText = "Fill in the ___";
         var hint = "test hint";
         var answer = "blank";
@@ -32,7 +33,7 @@ class FillInTheBlanksQuestionTest {
     @ValueSource(strings = {" ", "   ", "\t", "\n"})
     void constructorShouldThrowExceptionWhenIdIsInvalid(String id) {
         assertThrows(IllegalArgumentException.class, () ->
-            new FillInTheBlanksQuestion(id, "en", "Fill in the ___", "hint", "answer")
+            new FillInTheBlanksQuestion(id, Language.English, "Fill in the ___", "hint", "answer")
         );
     }
 
@@ -40,7 +41,7 @@ class FillInTheBlanksQuestionTest {
     @ValueSource(strings = {"", " ", "   ", "\t", "\n", "No blank here", "Multiple___ ___blanks", "Wrong blank --"})
     void constructorShouldThrowExceptionWhenQuestionTextIsInvalid(String questionText) {
         assertThrows(IllegalArgumentException.class, () ->
-            new FillInTheBlanksQuestion("id", "en", questionText, "hint", "answer")
+            new FillInTheBlanksQuestion("id", Language.English, questionText, "hint", "answer")
         );
     }
 
@@ -48,22 +49,14 @@ class FillInTheBlanksQuestionTest {
     @ValueSource(strings = {"", " ", "   ", "\t", "\n"})
     void constructorShouldThrowExceptionWhenAnswerIsInvalid(String answer) {
         assertThrows(IllegalArgumentException.class, () ->
-            new FillInTheBlanksQuestion("id", "en", "Fill in the ___", "hint", answer)
-        );
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {" ", "   ", "\t", "\n"})
-    void constructorShouldThrowExceptionWhenLanguageIsInvalid(String language) {
-        assertThrows(IllegalArgumentException.class, () ->
-            new FillInTheBlanksQuestion("id", language, "Fill in the ___", "hint", "answer")
+            new FillInTheBlanksQuestion("id", Language.English, "Fill in the ___", "hint", answer)
         );
     }
 
     @Test
     void assessAttemptShouldReturnSuccessForCorrectAnswer() {
         var question = new FillInTheBlanksQuestion(
-            "id", "en", "Fill in the ___", "hint", "correct"
+            "id", Language.English, "Fill in the ___", "hint", "correct"
         );
         var request = new FillInTheBlanksAttemptRequest(question.getID(), question.answer);
 
@@ -76,7 +69,7 @@ class FillInTheBlanksQuestionTest {
     @Test
     void assessAttemptShouldReturnFailureForIncorrectAnswer() {
         var question = new FillInTheBlanksQuestion(
-            "id", "en", "Fill in the ___", "hint", "correct"
+            "id", Language.English, "Fill in the ___", "hint", "correct"
         );
         var request = new FillInTheBlanksAttemptRequest(question.getID(), "wrong");
 

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCaseTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCaseTest.java
@@ -3,6 +3,7 @@ package com.munetmo.lingetic.LanguageTestService.UseCases;
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests.FillInTheBlanksAttemptRequest;
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.AttemptResponse;
 import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
+import com.munetmo.lingetic.LanguageTestService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionNotFoundException;
 import com.munetmo.lingetic.LanguageTestService.infra.Repositories.InMemory.QuestionInMemoryRepository;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.FillInTheBlanksQuestion;
@@ -27,7 +28,7 @@ class AttemptQuestionUseCaseTest {
 
         questionRepository.addQuestion(new FillInTheBlanksQuestion(
             "1",
-            "en",
+            Language.English,
             "The cat ____ lazily on the windowsill.",
             "straighten or extend one's body",
             "stretched"
@@ -68,7 +69,7 @@ class AttemptQuestionUseCaseTest {
     void shouldUpdateReviewWithHighScoreOnSuccessfulAttempt() throws QuestionNotFoundException {
         var question = new FillInTheBlanksQuestion(
             "1",
-            "en",
+            Language.English,
             "The cat ____ lazily on the windowsill.",
             "straighten or extend one's body",
             "stretched"
@@ -87,7 +88,7 @@ class AttemptQuestionUseCaseTest {
     void shouldUpdateReviewWithLowScoreOnFailedAttempt() throws QuestionNotFoundException {
         var question = new FillInTheBlanksQuestion(
             "1",
-            "en",
+            Language.English,
             "The cat ____ lazily on the windowsill.",
             "straighten or extend one's body",
             "stretched"

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/TakeRegularTestUseCaseTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/TakeRegularTestUseCaseTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.IntStream;
 
+import com.munetmo.lingetic.LanguageTestService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Repositories.QuestionRepository;
 import com.munetmo.lingetic.LanguageTestService.infra.Repositories.InMemory.QuestionReviewInMemoryRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,7 +31,7 @@ class TakeRegularTestUseCaseTest {
     private void addTestQuestions(int count) {
         IntStream.rangeClosed(1, count).forEach(i -> questionRepository.addQuestion(new FillInTheBlanksQuestion(
                 String.valueOf(i),
-                "en",
+                Language.English,
                 "Question " + i + ": He ____ to school.",
                 "motion verb",
                 "walks"
@@ -62,7 +63,7 @@ class TakeRegularTestUseCaseTest {
         int questionsCount = TakeRegularTestUseCase.limit - 5;
         addTestQuestions(questionsCount);
 
-        List<QuestionDTO> result = useCase.execute("en");
+        List<QuestionDTO> result = useCase.execute(Language.English);
 
         assertEquals(questionsCount, result.size());
         assertTrue(result.stream().allMatch(Objects::nonNull));
@@ -73,7 +74,7 @@ class TakeRegularTestUseCaseTest {
         int questionsCount = TakeRegularTestUseCase.limit + 5;
         addTestQuestions(questionsCount);
 
-        List<QuestionDTO> result = useCase.execute("en");
+        List<QuestionDTO> result = useCase.execute(Language.English);
 
         assertEquals(TakeRegularTestUseCase.limit, result.size());
         assertTrue(result.stream().allMatch(Objects::nonNull));
@@ -81,29 +82,29 @@ class TakeRegularTestUseCaseTest {
 
     @Test
     void shouldReturnEmptyListWhenNoQuestionsExist() {
-        List<QuestionDTO> result = useCase.execute("en");
+        List<QuestionDTO> result = useCase.execute(Language.English);
 
         assertTrue(result.isEmpty());
     }
 
     @Test
     void shouldOnlyReturnQuestionsInRequestedLanguage() {
-        questionRepository.addQuestion(new FillInTheBlanksQuestion("1", "en", "He ____ to school.", "motion verb", "walks"));
-        questionRepository.addQuestion(new FillInTheBlanksQuestion("2", "es", "El ____ a la escuela.", "verbo de movimiento", "camina"));
-        questionRepository.addQuestion(new FillInTheBlanksQuestion("3", "en", "She ____ fast.", "motion verb", "runs"));
-        questionRepository.addQuestion(new FillInTheBlanksQuestion("4", "fr", "Il ____ à l'école.", "verbe de mouvement", "marche"));
+        questionRepository.addQuestion(new FillInTheBlanksQuestion("1", Language.English, "He ____ to school.", "motion verb", "walks"));
+        questionRepository.addQuestion(new FillInTheBlanksQuestion("2", Language.DummyLanguage, "El ____ a la escuela.", "verbo de movimiento", "camina"));
+        questionRepository.addQuestion(new FillInTheBlanksQuestion("3", Language.English, "She ____ fast.", "motion verb", "runs"));
+        questionRepository.addQuestion(new FillInTheBlanksQuestion("4", Language.DummyLanguage, "Il ____ à l'école.", "verbe de mouvement", "marche"));
 
-        List<QuestionDTO> result = useCase.execute("en");
+        List<QuestionDTO> result = useCase.execute(Language.English);
 
         assertEquals(2, result.size());
-        assertTrue(result.stream().allMatch(q -> q.getLanguage().equals("en")));
+        assertTrue(result.stream().allMatch(q -> q.getLanguage().equals(Language.English)));
     }
 
     @Test
     void shouldReturnNewQuestionsIfNoQuestionsToReview() {
         addTestQuestions(TakeRegularTestUseCase.limit);
 
-        var result = useCase.execute("en");
+        var result = useCase.execute(Language.English);
 
         assertEquals(TakeRegularTestUseCase.limit, result.size());
     }
@@ -111,13 +112,13 @@ class TakeRegularTestUseCaseTest {
     @Test
     void shouldReturnQuestionsScheduledForReview() {
         addTestQuestions(TakeRegularTestUseCase.limit);
-        var reviewedQuestion = new FillInTheBlanksQuestion("rq1", "en", "He ____ to school.", "motion verb", "walks");
+        var reviewedQuestion = new FillInTheBlanksQuestion("rq1", Language.English, "He ____ to school.", "motion verb", "walks");
         questionRepository.addQuestion(reviewedQuestion);
         var questionReview = questionReviewRepository.getReviewForQuestionOrCreateNew(reviewedQuestion);
         questionReview.review(1);
         questionReviewRepository.update(questionReview);
 
-        var result = useCase.execute("en");
+        var result = useCase.execute(Language.English);
 
         assertTrue(result.stream().anyMatch(q -> q.getID().equals(reviewedQuestion.getID())));
     }
@@ -127,7 +128,7 @@ class TakeRegularTestUseCaseTest {
         addTestQuestions(TakeRegularTestUseCase.limit);
         reviewNQuestions(TakeRegularTestUseCase.limit / 2, 1, 0);
 
-        var result = useCase.execute("en");
+        var result = useCase.execute(Language.English);
 
         assertEquals(TakeRegularTestUseCase.limit, result.stream().map(QuestionDTO::getID).distinct().count());
     }
@@ -141,7 +142,7 @@ class TakeRegularTestUseCaseTest {
                 .map(r -> r.questionID)
                 .toList();
 
-        var result = useCase.execute("en");
+        var result = useCase.execute(Language.English);
 
         assertFalse(result.stream().anyMatch(q -> reviewedQuestionIDs.contains(q.getID())));
     }
@@ -151,7 +152,7 @@ class TakeRegularTestUseCaseTest {
         addTestQuestions(TakeRegularTestUseCase.limit);
         reviewNQuestions(TakeRegularTestUseCase.limit, 5, 0);
 
-        var result = useCase.execute("en");
+        var result = useCase.execute(Language.English);
 
         assertEquals(TakeRegularTestUseCase.limit, result.size());
     }
@@ -162,7 +163,7 @@ class TakeRegularTestUseCaseTest {
         reviewNQuestions(1, 1, 0);
         reviewNQuestions(1, 5, 1);
 
-        var result = useCase.execute("en");
+        var result = useCase.execute(Language.English);
 
         assertEquals(TakeRegularTestUseCase.limit / 2, result.size());
     }


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduced `Language` enum to standardize language representation.

- Updated DTOs, entities, and repositories to use `Language` enum.

- Enhanced HTTP controller to validate and handle `Language` enum.

- Refactored and added tests to ensure compatibility with `Language` enum.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td><strong>FillInTheBlanksQuestionDTO.java</strong><dd><code>Refactored `FillInTheBlanksQuestionDTO` to use `Language` enum</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/62/files#diff-fa213b6fcea598170beee82aacbd0950ae8777132b472697dac49c121e887ce6">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>QuestionDTO.java</strong><dd><code>Updated `QuestionDTO` interface to use `Language` enum</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/62/files#diff-b4f6d517766f87823fff5027e68bcd672c3e16ba706f87202ed475de7eee4eeb">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Language.java</strong><dd><code>Added `Language` enum for standardized language representation</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/62/files#diff-26252f2e30b4171168c4dd2faef76401b9fdceb9804eaaaf6ab72b92b0485545">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LanguageModel.java</strong><dd><code>Updated `LanguageModel` to use `Language` enum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/62/files#diff-1b767c3a07f514030a017ea4a474414b983a74fde3be1fce1c62734e9285e165">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>QuestionReview.java</strong><dd><code>Refactored `QuestionReview` to use `Language` enum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/62/files#diff-0f173b5b514afedc04e318a8bc97b47af93868d6698fad588bae75ca46fb64ed">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>FillInTheBlanksQuestion.java</strong><dd><code>Refactored `FillInTheBlanksQuestion` to use `Language` enum</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/62/files#diff-9d7d86a8c1cbe2e930918d9e5a4021a7c1d4930d95984dc745674893181140f3">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Question.java</strong><dd><code>Updated `Question` interface to use `Language` enum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/62/files#diff-a0e0605d676bd6e65c6af8054f1c9e9838989929823ebd9475e063388d873d0f">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>QuestionRepository.java</strong><dd><code>Updated `QuestionRepository` methods to use `Language` enum</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/62/files#diff-78255af545c8812fb069c5bdfef2377c32dff887364e0adde53987da44ae09d7">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>QuestionReviewRepository.java</strong><dd><code>Updated `QuestionReviewRepository` methods to use `Language` enum</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/62/files#diff-0e28bf5921aad22d43ec575c10e54b8a7b92003827b652f8b8b442a942f2f065">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TakeRegularTestUseCase.java</strong><dd><code>Refactored `TakeRegularTestUseCase` to use `Language` enum</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/62/files#diff-572f192a7c115ca5a0e26ca31f1578afe9f28f391794233cf01295f3a33c4be3">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>QuestionsController.java</strong><dd><code>Enhanced `QuestionsController` to validate `Language` enum</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/62/files#diff-c36dc4682e666603d6c2c01dc252f4c96ff6b4983613f5985e8e8fb5613e7bb2">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>QuestionInMemoryRepository.java</strong><dd><code>Updated in-memory question repository to use `Language` enum</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/62/files#diff-cf743cff6036639351429427a97c9d2459d8f5c3480a16109d5d736f50833f0f">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>QuestionReviewInMemoryRepository.java</strong><dd><code>Updated in-memory question review repository to use `Language` enum</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/62/files#diff-01e53b3fbd94291139029618e0d6fedafe4bcdae1f0599f98951152ccebda0b9">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>Updated frontend language list to align with `Language` enum</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/62/files#diff-40a777f3cdffde82bcb194a9a491938b9b71ea097fb6161af1067353cfa9209d">+6/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>FillInTheBlanksQuestionDTOTest.java</strong><dd><code>Updated tests for `FillInTheBlanksQuestionDTO` to use `Language` enum</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/62/files#diff-5ba7be7435286726432203ffa1e026197c626b84f55b52a0266050595d0c3b04">+6/-13</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>QuestionDTOTest.java</strong><dd><code>Updated tests for `QuestionDTO` to use `Language` enum</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/62/files#diff-a6903e4b0031d84c303aa4c979ef61300fe747c0a8edd8510272e4d2b6457ee9">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>QuestionReviewTest.java</strong><dd><code>Updated tests for `QuestionReview` to use `Language` enum</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/62/files#diff-b9ca5865200a51bf0df0f5ace46ce8b51f515949eeace9ecc21a6a7b9ee40287">+6/-12</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>FillInTheBlanksQuestionTest.java</strong><dd><code>Updated tests for `FillInTheBlanksQuestion` to use `Language` enum</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/62/files#diff-0a3416aadee18c0ed2c84823014f4921e4d5f6f02115bfda63a633e1d265a867">+7/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AttemptQuestionUseCaseTest.java</strong><dd><code>Updated tests for `AttemptQuestionUseCase` to use `Language` enum</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/62/files#diff-6564db7713f761ac261226011bd4890a7331c730ae57545f0ca164f5c2eadc79">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TakeRegularTestUseCaseTest.java</strong><dd><code>Updated tests for `TakeRegularTestUseCase` to use `Language` enum</code></dd></td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/62/files#diff-a6198b6ed08529c39d68e286f8a8517ca2237e510b1ac4a965e037d8a17a5c45">+18/-17</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the language selection page to replace previous options with “English” and a new “Random” language, offering a refreshed choice for users.

- **Refactor**
  - Enhanced language handling across the application to ensure consistent input validation and clearer error messaging for invalid language selections, thereby improving the overall user experience.
  - Transitioned from string representations of languages to a structured `Language` enum, enhancing type safety and clarity throughout the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->