### PR TITLE
Secure the backend using Clerk

### DIFF
--- a/lingetic-nextjs-frontend/app/components/questions/FillInTheBlanks/useUserAnswer.ts
+++ b/lingetic-nextjs-frontend/app/components/questions/FillInTheBlanks/useUserAnswer.ts
@@ -6,11 +6,13 @@ import type {
   FillInTheBlanksAttemptResponse,
 } from "@/utilities/api-types";
 import assert from "@/utilities/assert";
+import { useAuth } from "@clerk/nextjs";
 
 export default function useUserAnswer(questionID: string) {
   assert(questionID?.trim()?.length > 0, "questionId is required");
 
   const [answer, setAnswer] = useState("");
+  const { getToken } = useAuth();
 
   const attemptChallengeMutation = useMutation<
     FillInTheBlanksAttemptResponse,
@@ -24,7 +26,7 @@ export default function useUserAnswer(questionID: string) {
         userResponse,
       } as FillInTheBlanksAttemptRequest;
 
-      return attemptQuestion(attemptRequest);
+      return attemptQuestion(attemptRequest, getToken);
     },
   });
 

--- a/lingetic-nextjs-frontend/app/languages/learn/[language]/useQuestions.ts
+++ b/lingetic-nextjs-frontend/app/languages/learn/[language]/useQuestions.ts
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { fetchQuestions } from "@/utilities/api";
 import assert from "@/utilities/assert";
 import type { Question } from "@/utilities/api-types";
+import { useAuth } from "@clerk/nextjs";
 
 interface UseQuestionsParams {
   onFinish: () => void;
@@ -48,13 +49,15 @@ export default function useQuestions({
 }: UseQuestionsParams): UseQuestionsResult {
   assert(language?.trim()?.length > 0, "language is required");
 
+  const { getToken } = useAuth();
+
   const {
     data: questions = [],
     isLoading,
     isError,
   } = useQuery({
     queryKey: ["questions", language],
-    queryFn: () => fetchQuestions(language),
+    queryFn: () => fetchQuestions(language, getToken),
 
     // The same questions should not be displayed on different renders
     // of the component. This is because the questions that Lingetic thinks

--- a/lingetic-nextjs-frontend/utilities/api.ts
+++ b/lingetic-nextjs-frontend/utilities/api.ts
@@ -10,9 +10,13 @@ async function fetchOrThrow<T>(url: string, options?: RequestInit): Promise<T> {
 }
 
 export async function attemptQuestion<T extends AttemptResponse>(
-  attemptRequest: AttemptRequest
+  attemptRequest: AttemptRequest,
+  getToken: () => Promise<string | null>
 ): Promise<T> {
   validateAttemptRequestOrDie(attemptRequest);
+
+  const token = await getToken();
+  assert(token !== null, "Token was null when attempting question");
 
   return await fetchOrThrow(
     `${process.env.NEXT_PUBLIC_API_BASE_URL}/questions/attempt`,
@@ -20,19 +24,27 @@ export async function attemptQuestion<T extends AttemptResponse>(
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify(attemptRequest),
     }
   );
 }
 
-export async function fetchQuestions(language: string): Promise<Question[]> {
+export async function fetchQuestions(language: string, getToken: () => Promise<string | null>): Promise<Question[]> {
   assert(language?.trim()?.length > 0, "language is required");
 
+  const token = await getToken();
+  assert(token !== null, "Token was null when fetching questions");
+  
   const encodedLanguage = encodeURIComponent(language);
 
   return await fetchOrThrow(
-    `${process.env.NEXT_PUBLIC_API_BASE_URL}/questions?language=${encodedLanguage}`
+    `${process.env.NEXT_PUBLIC_API_BASE_URL}/questions?language=${encodedLanguage}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    }
   );
 }
 

--- a/lingetic-spring-backend/build.gradle.kts
+++ b/lingetic-spring-backend/build.gradle.kts
@@ -24,6 +24,8 @@ repositories {
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springframework.boot:spring-boot-starter-security")
+	implementation("com.clerk:backend-api:1.5.0")
 	developmentOnly("org.springframework.boot:spring-boot-devtools")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/HTTP/QuestionsController.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/HTTP/QuestionsController.java
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import com.munetmo.lingetic.LanguageTestService.UseCases.AttemptQuestionUseCase;
 import com.munetmo.lingetic.LanguageTestService.UseCases.TakeRegularTestUseCase;
 
-@CrossOrigin(origins = "${spring.web.cors.allowed-origins}")
 @RestController
 @RequestMapping("/questions")
 public class QuestionsController {

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/infra/auth/ClerkAuthentication.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/infra/auth/ClerkAuthentication.java
@@ -1,0 +1,38 @@
+package com.munetmo.lingetic.infra.auth;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+
+public class ClerkAuthentication extends AbstractAuthenticationToken {
+    private final Object principal;
+
+    public ClerkAuthentication(Object principal) {
+        super(AuthorityUtils.NO_AUTHORITIES);
+        this.principal = principal;
+        super.setAuthenticated(true);
+    }
+
+    @Override
+    @Nullable
+    public Object getCredentials() {
+        // No password is involved; short-lived JWT is used for authentication
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return principal;
+    }
+
+    @Override
+    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+        if (isAuthenticated) {
+            throw new IllegalArgumentException(
+                "Authentication is managed by Clerk. Cannot set isAuthenticated to true after construction."
+            );
+        }
+
+        super.setAuthenticated(false);
+    }
+}

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/infra/auth/ClerkAuthenticationFilter.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/infra/auth/ClerkAuthenticationFilter.java
@@ -1,0 +1,71 @@
+package com.munetmo.lingetic.infra.auth;
+
+import com.clerk.backend_api.helpers.jwks.AuthenticateRequest;
+import com.clerk.backend_api.helpers.jwks.AuthenticateRequestOptions;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpRequest;
+
+@Component
+public class  ClerkAuthenticationFilter extends OncePerRequestFilter {
+    @Value("${clerk.apiKey}")
+    @Nullable
+    private String clerkAPIKey;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        if (clerkAPIKey == null) {
+            throw new IllegalStateException("Clerk API key is not set");
+        }
+
+        if (!request.getHeader("Authorization").startsWith("Bearer ")) {
+            onUnauthorized(response);
+            return;
+        }
+
+        var requestState = AuthenticateRequest.authenticateRequest(
+                createHttpRequestForClerk(request),
+                AuthenticateRequestOptions
+                    .secretKey(clerkAPIKey)
+                    .build()
+        );
+
+        if (requestState.isSignedOut()) {
+            onUnauthorized(response);
+            return;
+        }
+
+        var authentication = new ClerkAuthentication(requestState.claims());
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        chain.doFilter(request, response);
+    }
+
+    private void onUnauthorized(HttpServletResponse response) throws IOException {
+        SecurityContextHolder.clearContext();
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+
+    private HttpRequest createHttpRequestForClerk(HttpServletRequest servletRequest) {
+        var authHeader = servletRequest.getHeader("Authorization");
+        var uri = servletRequest.getRequestURL().toString();
+
+        return HttpRequest.newBuilder()
+                .uri(URI.create(uri))
+                .header("Authorization", authHeader)
+                .build();
+    }
+}

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/infra/auth/SecurityConfig.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/infra/auth/SecurityConfig.java
@@ -1,0 +1,71 @@
+package com.munetmo.lingetic.infra.auth;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+import java.util.Objects;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    private final ClerkAuthenticationFilter clerkAuthenticationFilter;
+
+    @Value("${spring.web.cors.allowed-origins}")
+    @Nullable
+    private String allowedOrigins;
+
+    public SecurityConfig(ClerkAuthenticationFilter clerkAuthenticationFilter) {
+        this.clerkAuthenticationFilter = clerkAuthenticationFilter;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+                .exceptionHandling(exception -> exception.authenticationEntryPoint(unauthorizedHandler()))
+                .addFilterBefore(clerkAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        if (allowedOrigins == null) {
+            throw new IllegalStateException("Allowed origins is not set");
+        }
+
+        var configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of(allowedOrigins.split(",")));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+
+        var source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+    private AuthenticationEntryPoint unauthorizedHandler() {
+        return (request, response, authException) -> {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json");
+            response.getWriter().write("{\"error\": \"Unauthorized\"}");
+        };
+    }
+}


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Implemented backend authentication using Clerk with JWT.

- Added security configurations for CORS and stateless sessions.

- Integrated Clerk authentication in frontend API calls.

- Updated dependencies to include Clerk and Spring Security.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ClerkAuthentication.java</strong><dd><code>Added Clerk authentication token class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-spring-backend/src/main/java/com/munetmo/lingetic/infra/auth/ClerkAuthentication.java

<li>Added <code>ClerkAuthentication</code> class extending <code>AbstractAuthenticationToken</code>.<br> <li> Implemented methods for principal and credentials handling.<br> <li> Set up authentication using short-lived JWT.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/65/files#diff-92b887ee8a53cc37a54f54af2cac32260b7a8a0494b477c3e631ead5968b5677">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ClerkAuthenticationFilter.java</strong><dd><code>Added Clerk authentication filter for requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-spring-backend/src/main/java/com/munetmo/lingetic/infra/auth/ClerkAuthenticationFilter.java

<li>Created <code>ClerkAuthenticationFilter</code> for request filtering.<br> <li> Integrated Clerk API for JWT validation.<br> <li> Added error handling for unauthorized requests.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/65/files#diff-960abbed32dffd4638b7c990285e2fc3770842d8d17b3243b1190a8b2e959139">+65/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SecurityConfig.java</strong><dd><code>Configured security settings and Clerk filter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-spring-backend/src/main/java/com/munetmo/lingetic/infra/auth/SecurityConfig.java

<li>Configured security settings for CORS and stateless sessions.<br> <li> Integrated <code>ClerkAuthenticationFilter</code> into the security chain.<br> <li> Added custom unauthorized response handler.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/65/files#diff-1436b82ff81b1bdd04e10d3f3e8681d16238fdc44f7c9c1ad09af1005704a09e">+71/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useUserAnswer.ts</strong><dd><code>Integrated Clerk authentication in user answers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-nextjs-frontend/app/components/questions/FillInTheBlanks/useUserAnswer.ts

<li>Integrated Clerk's <code>useAuth</code> to fetch JWT token.<br> <li> Updated <code>attemptQuestion</code> call to include token.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/65/files#diff-78500ba21fe64cbcda494236b7393931c21fc24895c63ade97ee9fff1202835e">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useQuestions.ts</strong><dd><code>Integrated Clerk authentication in question fetching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-nextjs-frontend/app/languages/learn/[language]/useQuestions.ts

<li>Integrated Clerk's <code>useAuth</code> to fetch JWT token.<br> <li> Updated <code>fetchQuestions</code> call to include token.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/65/files#diff-d7d0ccb9c3120129bc3aedd23647f7333f31b59cca2816e27fdde66855b6d1bc">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>api.ts</strong><dd><code>Enhanced API calls with Clerk authentication</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-nextjs-frontend/utilities/api.ts

<li>Updated <code>attemptQuestion</code> and <code>fetchQuestions</code> to include JWT token.<br> <li> Added token validation before API calls.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/65/files#diff-aba4102025e1b36635c71b4ac083b6f232f5fbeaf576a678426fd920da372410">+15/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build.gradle.kts</strong><dd><code>Updated dependencies for Clerk and security</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-spring-backend/build.gradle.kts

- Added dependencies for Spring Security and Clerk backend API.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/65/files#diff-113df45046b212d0b0388a415b8999bef405f54e490fd218bb3e9fd2191feb66">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled token-based authentication for secure question retrieval and challenge attempts.
  - Introduced a comprehensive security configuration to manage authentication and CORS handling.
  - Enhanced user authentication flow with new classes for managing Clerk API interactions.

- **Chores**
  - Updated backend dependencies to integrate Spring Security and Clerk backend API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->