### PR TITLE
Use JWT claims as the principal for authentication

### DIFF
--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/infra/auth/ClerkAuthentication.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/infra/auth/ClerkAuthentication.java
@@ -1,13 +1,14 @@
 package com.munetmo.lingetic.infra.auth;
 
+import io.jsonwebtoken.Claims;
 import org.jspecify.annotations.Nullable;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.authority.AuthorityUtils;
 
 public class ClerkAuthentication extends AbstractAuthenticationToken {
-    private final Object principal;
+    private final Claims principal;
 
-    public ClerkAuthentication(Object principal) {
+    public ClerkAuthentication(Claims principal) {
         super(AuthorityUtils.NO_AUTHORITIES);
         this.principal = principal;
         super.setAuthenticated(true);

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/infra/auth/ClerkAuthenticationFilter.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/infra/auth/ClerkAuthenticationFilter.java
@@ -47,7 +47,13 @@ public class  ClerkAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
 
-        var authentication = new ClerkAuthentication(requestState.claims());
+        var claims = requestState.claims();
+        if (claims.isEmpty()) {
+            onUnauthorized(response);
+            return;
+        }
+
+        var authentication = new ClerkAuthentication(claims.get());
         authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
         SecurityContextHolder.getContext().setAuthentication(authentication);
 


### PR DESCRIPTION
The JWT claims' sub will be used as the user ID in
future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling in the authentication process to prevent issues when incomplete credential data is encountered.

- **Refactor**
  - Updated how authentication tokens are processed, ensuring the system aligns with current security standards for a more reliable user login experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->