### PR TITLE
Use a supplier to get question list

### DIFF
--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/QuestionDTOTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/QuestionDTOTest.java
@@ -5,10 +5,14 @@ import com.munetmo.lingetic.LanguageTestService.Entities.QuestionList;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.FillInTheBlanksQuestion;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
 import org.junit.jupiter.api.Test;
+
+import java.util.function.Supplier;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class QuestionDTOTest {
     private static final QuestionList TEST_QUESTION_LIST = new QuestionList("test-list", "Test QuestionList");
+    private static final Supplier<QuestionList> TEST_QUESTION_LIST_SUPPLIER = () -> TEST_QUESTION_LIST;
 
     @Test
     void shouldConvertFillInTheBlanksQuestionToDTO() {
@@ -19,7 +23,7 @@ class QuestionDTOTest {
             "This is a hint",
             "test answer",
             5,
-                TEST_QUESTION_LIST
+            TEST_QUESTION_LIST_SUPPLIER
         );
 
         QuestionDTO dto = QuestionDTO.fromQuestion(question);

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestionTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestionTest.java
@@ -9,10 +9,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.function.Supplier;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class FillInTheBlanksQuestionTest {
     private final QuestionList defaultQuestionList = new QuestionList("list-id", "Test QuestionList");
+    private final Supplier<QuestionList> defaultQuestionListSupplier = () -> defaultQuestionList;
 
     @Test
     void constructorShouldCreateValidObjectWithCorrectValues() {
@@ -22,7 +25,7 @@ class FillInTheBlanksQuestionTest {
         var hint = "test hint";
         var answer = "blank";
 
-        FillInTheBlanksQuestion question = new FillInTheBlanksQuestion(id, language, questionText, hint, answer, 5, defaultQuestionList);
+        FillInTheBlanksQuestion question = new FillInTheBlanksQuestion(id, language, questionText, hint, answer, 5, defaultQuestionListSupplier);
 
         assertEquals(id, question.getID());
         assertEquals(language, question.getLanguage());
@@ -38,7 +41,7 @@ class FillInTheBlanksQuestionTest {
     @ValueSource(strings = {" ", "   ", "\t", "\n"})
     void constructorShouldThrowExceptionWhenIdIsInvalid(String id) {
         assertThrows(IllegalArgumentException.class, () ->
-            new FillInTheBlanksQuestion(id, Language.English, "Fill in the ___", "hint", "answer", 5, defaultQuestionList)
+            new FillInTheBlanksQuestion(id, Language.English, "Fill in the ___", "hint", "answer", 5, defaultQuestionListSupplier)
         );
     }
 
@@ -46,7 +49,7 @@ class FillInTheBlanksQuestionTest {
     @ValueSource(strings = {"", " ", "   ", "\t", "\n", "No blank here", "Multiple___ ___blanks", "Wrong blank --"})
     void constructorShouldThrowExceptionWhenQuestionTextIsInvalid(String questionText) {
         assertThrows(IllegalArgumentException.class, () ->
-            new FillInTheBlanksQuestion("id", Language.English, questionText, "hint", "answer", 5, defaultQuestionList)
+            new FillInTheBlanksQuestion("id", Language.English, questionText, "hint", "answer", 5, defaultQuestionListSupplier)
         );
     }
 
@@ -54,14 +57,14 @@ class FillInTheBlanksQuestionTest {
     @ValueSource(strings = {"", " ", "   ", "\t", "\n"})
     void constructorShouldThrowExceptionWhenAnswerIsInvalid(String answer) {
         assertThrows(IllegalArgumentException.class, () ->
-            new FillInTheBlanksQuestion("id", Language.English, "Fill in the ___", "hint", answer, 5, defaultQuestionList)
+            new FillInTheBlanksQuestion("id", Language.English, "Fill in the ___", "hint", answer, 5, defaultQuestionListSupplier)
         );
     }
 
     @Test
     void assessAttemptShouldReturnSuccessForCorrectAnswer() {
         var question = new FillInTheBlanksQuestion(
-            "id", Language.English, "Fill in the ___", "hint", "correct", 5, defaultQuestionList
+            "id", Language.English, "Fill in the ___", "hint", "correct", 5, defaultQuestionListSupplier
         );
         var request = new FillInTheBlanksAttemptRequest(question.getID(), question.answer);
 
@@ -74,7 +77,7 @@ class FillInTheBlanksQuestionTest {
     @Test
     void assessAttemptShouldReturnFailureForIncorrectAnswer() {
         var question = new FillInTheBlanksQuestion(
-            "id", Language.English, "Fill in the ___", "hint", "correct", 5, defaultQuestionList
+            "id", Language.English, "Fill in the ___", "hint", "correct", 5, defaultQuestionListSupplier
         );
         var request = new FillInTheBlanksAttemptRequest(question.getID(), "wrong");
 

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCaseTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCaseTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -22,6 +23,7 @@ class AttemptQuestionUseCaseTest {
     private QuestionReviewInMemoryRepository questionReviewRepository;
     private static final String TEST_USER_ID = "test-user-1";
     private static final QuestionList TEST_QUESTION_LIST = new QuestionList("test-list", "Test QuestionList");
+    private static final Supplier<QuestionList> TEST_QUESTION_LIST_SUPPLIER = () -> TEST_QUESTION_LIST;
 
     @BeforeEach
     void setUp() {
@@ -36,7 +38,7 @@ class AttemptQuestionUseCaseTest {
             "straighten or extend one's body",
             "stretched",
             0,
-                TEST_QUESTION_LIST
+            TEST_QUESTION_LIST_SUPPLIER
         ));
     }
 
@@ -79,7 +81,7 @@ class AttemptQuestionUseCaseTest {
             "straighten or extend one's body",
             "stretched",
             0,
-                TEST_QUESTION_LIST
+            TEST_QUESTION_LIST_SUPPLIER
         );
         var request = new FillInTheBlanksAttemptRequest(question.getID(), "stretched");
         var before = Instant.now();
@@ -100,7 +102,7 @@ class AttemptQuestionUseCaseTest {
             "straighten or extend one's body",
             "stretched",
             0,
-                TEST_QUESTION_LIST
+            TEST_QUESTION_LIST_SUPPLIER
         );
         var request = new FillInTheBlanksAttemptRequest(question.getID(), "wrong answer");
         var before = Instant.now();

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/TakeRegularTestUseCaseTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/TakeRegularTestUseCaseTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
 import com.munetmo.lingetic.LanguageTestService.DTOs.Question.QuestionDTO;
@@ -23,6 +24,7 @@ class TakeRegularTestUseCaseTest {
 
     private static final String TEST_USER_ID = "test-user-1";
     private static final QuestionList TEST_QUESTION_LIST = new QuestionList("test-list", "Test QuestionList");
+    private static final Supplier<QuestionList> TEST_QUESTION_LIST_SUPPLIER = () -> TEST_QUESTION_LIST;
 
     @BeforeEach
     void setUp() {
@@ -39,7 +41,7 @@ class TakeRegularTestUseCaseTest {
                 "motion verb",
                 "walks",
                 0,
-                TEST_QUESTION_LIST
+                TEST_QUESTION_LIST_SUPPLIER
         )));
     }
 
@@ -94,10 +96,10 @@ class TakeRegularTestUseCaseTest {
 
     @Test
     void shouldOnlyReturnQuestionsInRequestedLanguage() {
-        questionRepository.addQuestion(new FillInTheBlanksQuestion("1", Language.English, "He ____ to school.", "motion verb", "walks", 0, TEST_QUESTION_LIST));
-        questionRepository.addQuestion(new FillInTheBlanksQuestion("2", Language.DummyLanguage, "El ____ a la escuela.", "verbo de movimiento", "camina", 0, TEST_QUESTION_LIST));
-        questionRepository.addQuestion(new FillInTheBlanksQuestion("3", Language.English, "She ____ fast.", "motion verb", "runs", 0, TEST_QUESTION_LIST));
-        questionRepository.addQuestion(new FillInTheBlanksQuestion("4", Language.DummyLanguage, "Il ____ à l'école.", "verbe de mouvement", "marche", 0, TEST_QUESTION_LIST));
+        questionRepository.addQuestion(new FillInTheBlanksQuestion("1", Language.English, "He ____ to school.", "motion verb", "walks", 0, TEST_QUESTION_LIST_SUPPLIER));
+        questionRepository.addQuestion(new FillInTheBlanksQuestion("2", Language.DummyLanguage, "El ____ a la escuela.", "verbo de movimiento", "camina", 0, TEST_QUESTION_LIST_SUPPLIER));
+        questionRepository.addQuestion(new FillInTheBlanksQuestion("3", Language.English, "She ____ fast.", "motion verb", "runs", 0, TEST_QUESTION_LIST_SUPPLIER));
+        questionRepository.addQuestion(new FillInTheBlanksQuestion("4", Language.DummyLanguage, "Il ____ à l'école.", "verbe de mouvement", "marche", 0, TEST_QUESTION_LIST_SUPPLIER));
 
         List<QuestionDTO> result = useCase.execute(TEST_USER_ID, Language.English);
 
@@ -117,7 +119,7 @@ class TakeRegularTestUseCaseTest {
     @Test
     void shouldReturnQuestionsScheduledForReview() {
         addTestQuestions(TakeRegularTestUseCase.limit);
-        var reviewedQuestion = new FillInTheBlanksQuestion("rq1", Language.English, "He ____ to school.", "motion verb", "walks", 0, TEST_QUESTION_LIST);
+        var reviewedQuestion = new FillInTheBlanksQuestion("rq1", Language.English, "He ____ to school.", "motion verb", "walks", 0, TEST_QUESTION_LIST_SUPPLIER);
         questionRepository.addQuestion(reviewedQuestion);
         var questionReview = questionReviewRepository.getReviewForQuestionOrCreateNew(TEST_USER_ID, reviewedQuestion);
         questionReview.review(1);
@@ -175,9 +177,9 @@ class TakeRegularTestUseCaseTest {
 
     @Test
     void shouldReturnQuestionsOrderedByDifficulty() {
-        var question1 = new FillInTheBlanksQuestion("1", Language.English, "He ___ to school.", "motion verb", "walks", 3, TEST_QUESTION_LIST);
-        var question2 = new FillInTheBlanksQuestion("2", Language.English, "She ___ fast.", "motion verb", "runs", 1, TEST_QUESTION_LIST);
-        var question3 = new FillInTheBlanksQuestion("3", Language.English, "They ___ together.", "motion verb", "dance", 2, TEST_QUESTION_LIST);
+        var question1 = new FillInTheBlanksQuestion("1", Language.English, "He ___ to school.", "motion verb", "walks", 3, TEST_QUESTION_LIST_SUPPLIER);
+        var question2 = new FillInTheBlanksQuestion("2", Language.English, "She ___ fast.", "motion verb", "runs", 1, TEST_QUESTION_LIST_SUPPLIER);
+        var question3 = new FillInTheBlanksQuestion("3", Language.English, "They ___ together.", "motion verb", "dance", 2, TEST_QUESTION_LIST_SUPPLIER);
 
         questionRepository.addQuestion(question1);
         questionRepository.addQuestion(question2);
@@ -193,11 +195,11 @@ class TakeRegularTestUseCaseTest {
 
     @Test
     void shouldOnlyOrderQuestionsByDifficultyIfTheyAreUnreviewed() {
-        var question1 = new FillInTheBlanksQuestion("q1", Language.English, "He ___ to school.", "motion verb", "walks", 10, TEST_QUESTION_LIST);
-        var question2 = new FillInTheBlanksQuestion("q2", Language.English, "She ___ fast.", "motion verb", "runs", 5, TEST_QUESTION_LIST);
-        var question3 = new FillInTheBlanksQuestion("q3", Language.English, "They ___ together.", "motion verb", "dance", 8, TEST_QUESTION_LIST);
-        var question4 = new FillInTheBlanksQuestion("q4", Language.English, "I ___ to work.", "motion verb", "drive", 4, TEST_QUESTION_LIST);
-        var question5 = new FillInTheBlanksQuestion("q5", Language.English, "We ___ home.", "motion verb", "walk", 1, TEST_QUESTION_LIST);
+        var question1 = new FillInTheBlanksQuestion("q1", Language.English, "He ___ to school.", "motion verb", "walks", 10, TEST_QUESTION_LIST_SUPPLIER);
+        var question2 = new FillInTheBlanksQuestion("q2", Language.English, "She ___ fast.", "motion verb", "runs", 5, TEST_QUESTION_LIST_SUPPLIER);
+        var question3 = new FillInTheBlanksQuestion("q3", Language.English, "They ___ together.", "motion verb", "dance", 8, TEST_QUESTION_LIST_SUPPLIER);
+        var question4 = new FillInTheBlanksQuestion("q4", Language.English, "I ___ to work.", "motion verb", "drive", 4, TEST_QUESTION_LIST_SUPPLIER);
+        var question5 = new FillInTheBlanksQuestion("q5", Language.English, "We ___ home.", "motion verb", "walk", 1, TEST_QUESTION_LIST_SUPPLIER);
 
         questionRepository.addQuestion(question1);
         questionRepository.addQuestion(question2);


### PR DESCRIPTION
This allows the fetching of question list to be
delayed saving one DB call if a question list is
not required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the efficiency and thread safety of question handling, enabling more responsive language testing features.
- **Tests**
  - Updated automated tests to ensure continued stability and reliability of the language testing system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->