### PR TITLE
Add methods to work with question specific data

### DIFF
--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestion.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestion.java
@@ -9,6 +9,7 @@ import com.munetmo.lingetic.LanguageTestService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.LanguageModels.LanguageModel;
 import org.jspecify.annotations.Nullable;
 
+import java.util.Map;
 import java.util.Objects;
 
 public final class FillInTheBlanksQuestion implements Question {
@@ -93,5 +94,26 @@ public final class FillInTheBlanksQuestion implements Question {
     @Override
     public int getDifficulty() {
         return difficulty;
+    }
+
+    @Override
+    public Map<String, Object> getQuestionTypeSpecificData() {
+        return Map.of(
+            "questionText", questionText,
+            "hint", hint,
+            "answer", answer
+        );
+    }
+
+    public static FillInTheBlanksQuestion createFromQuestionTypeSpecificData(String id, Language language, int difficulty, String questionListId, Map<String, Object> data) {
+        if (!data.containsKey("questionText") || !data.containsKey("answer")) {
+            throw new IllegalArgumentException("Required fields 'questionText' and 'answer' must be present in data");
+        }
+
+        String questionText = (String) data.get("questionText");
+        String answer = (String) data.get("answer");
+        String hint = (String) data.getOrDefault("hint", "");
+
+        return new FillInTheBlanksQuestion(id, language, questionText, hint, answer, difficulty, questionListId);
     }
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/Question.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/Question.java
@@ -4,11 +4,22 @@ import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests.Att
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.AttemptResponse;
 import com.munetmo.lingetic.LanguageTestService.Entities.Language;
 
+import java.util.Map;
+
 public sealed interface Question permits FillInTheBlanksQuestion {
     String getID();
     QuestionType getQuestionType();
     Language getLanguage();
-    AttemptResponse assessAttempt(AttemptRequest request);
     int getDifficulty();
     String getQuestionListID();
+
+    Map<String, Object> getQuestionTypeSpecificData();
+    static Question createFromQuestionTypeSpecificData(String id, Language language, int difficulty, String questionListId, QuestionType questionType, Map<String, Object> data) {
+        return switch (questionType) {
+            case FillInTheBlanks -> FillInTheBlanksQuestion.createFromQuestionTypeSpecificData(id, language, difficulty, questionListId, data);
+            default -> throw new IllegalArgumentException("Unsupported question type");
+        };
+    }
+
+    AttemptResponse assessAttempt(AttemptRequest request);
 }

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestionTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestionTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class FillInTheBlanksQuestionTest {
@@ -89,5 +91,103 @@ class FillInTheBlanksQuestionTest {
 
         assertEquals(AttemptStatus.Failure, response.getAttemptStatus());
         assertEquals(question.answer, response.getCorrectAnswer());
+    }
+
+    @Test
+    void getQuestionTypeSpecificDataShouldReturnCorrectMap() {
+        var question = new FillInTheBlanksQuestion(
+            "test-id",
+            Language.English,
+            "Fill in the ___",
+            "test hint",
+            "blank",
+            5,
+            defaultQuestionListId
+        );
+
+        var data = question.getQuestionTypeSpecificData();
+
+        assertEquals("Fill in the ___", data.get("questionText"));
+        assertEquals("test hint", data.get("hint"));
+        assertEquals("blank", data.get("answer"));
+        assertEquals(3, data.size());
+    }
+
+    @Test
+    void createFromQuestionTypeSpecificDataShouldCreateEquivalentQuestion() {
+        var originalQuestion = new FillInTheBlanksQuestion(
+            "test-id",
+            Language.English,
+            "Fill in the ___",
+            "test hint",
+            "blank",
+            5,
+            defaultQuestionListId
+        );
+
+        var data = originalQuestion.getQuestionTypeSpecificData();
+        var newQuestion = FillInTheBlanksQuestion.createFromQuestionTypeSpecificData(
+            originalQuestion.getID(),
+            originalQuestion.getLanguage(),
+            originalQuestion.getDifficulty(),
+            originalQuestion.getQuestionListID(),
+            data
+        );
+
+        assertEquals(originalQuestion.getID(), newQuestion.getID());
+        assertEquals(originalQuestion.getLanguage(), newQuestion.getLanguage());
+        assertEquals(originalQuestion.getDifficulty(), newQuestion.getDifficulty());
+        assertEquals(originalQuestion.getQuestionListID(), newQuestion.getQuestionListID());
+        assertEquals(originalQuestion.questionText, ((FillInTheBlanksQuestion)newQuestion).questionText);
+        assertEquals(originalQuestion.hint, ((FillInTheBlanksQuestion)newQuestion).hint);
+        assertEquals(originalQuestion.answer, ((FillInTheBlanksQuestion)newQuestion).answer);
+    }
+
+    @Test
+    void createFromQuestionTypeSpecificDataShouldHandleMissingOptionalFields() {
+        Map<String, Object> data = Map.of(
+            "questionText", "Fill in the ___",
+            "answer", "blank"
+        );
+
+        var newQuestion = FillInTheBlanksQuestion.createFromQuestionTypeSpecificData(
+            "test-id",
+            Language.English,
+            5,
+            defaultQuestionListId,
+            data
+        );
+
+        assertEquals("", newQuestion.hint);
+    }
+
+    @Test
+    void createFromQuestionTypeSpecificDataShouldThrowExceptionWhenQuestionTextIsMissing() {
+        Map<String, Object> incompleteData = Map.of("answer", "blank");
+
+        assertThrows(IllegalArgumentException.class, () ->
+                FillInTheBlanksQuestion.createFromQuestionTypeSpecificData(
+                        "test-id",
+                        Language.English,
+                        5,
+                        defaultQuestionListId,
+                        incompleteData
+                )
+        );
+    }
+
+    @Test
+    void createFromQuestionTypeSpecificDataShouldThrowExceptionWhenAnswerIsMissing() {
+        Map<String, Object> incompleteData = Map.of("questionText", "Fill in the ___");
+
+        assertThrows(IllegalArgumentException.class, () ->
+                FillInTheBlanksQuestion.createFromQuestionTypeSpecificData(
+                        "test-id",
+                        Language.English,
+                        5,
+                        defaultQuestionListId,
+                        incompleteData
+                )
+        );
     }
 }


### PR DESCRIPTION
This will make reading and writing to DBs that
don't support object-oriented inheritance simpler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new methods to retrieve detailed question information and construct fill-in-the-blanks questions from structured data, ensuring a unified approach across question types.
- **Tests**
  - Enhanced test coverage to verify accurate data handling, proper question creation from external inputs, and robust error handling when required information is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->