### PR TITLE
Make failing frontend tests pass

### DIFF
--- a/lingetic-nextjs-frontend/__tests__/pages/learn/LearnPage.test.tsx
+++ b/lingetic-nextjs-frontend/__tests__/pages/learn/LearnPage.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, waitFor } from "@testing-library/react";
-import LearnPage from "@/app/languages/learn/[language]/page";
+import { LearnPageComponent } from "@/app/languages/learn/[language]/page";
 import { renderWithQueryClient } from "@/utilities/testing-helpers";
 import type { FillInTheBlanksQuestion, Question } from "@/utilities/api-types";
 
@@ -11,49 +11,49 @@ jest.mock("next/navigation", () => ({
   useParams: () => ({ language: "spanish" }),
 }));
 
-describe("LearnPage", () => {
+describe("LearnPageComponent", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it("shows loading text when loading", async () => {
     mockForeverPendingFetch();
-    const { findByText } = renderWithQueryClient(<LearnPage />);
+    const { findByText } = renderWithQueryClient(<LearnPageComponent />);
 
     expect(await findByText(/loading/i)).toBeInTheDocument();
   });
 
   it("shows error text when there is a network error", async () => {
     mockNetworkErrorFetch();
-    const { findByText } = renderWithQueryClient(<LearnPage />);
+    const { findByText } = renderWithQueryClient(<LearnPageComponent />);
 
     expect(await findByText(/failed/i)).toBeInTheDocument();
   });
 
   it("shows error when request resolves unsuccessfully", async () => {
     mockServerErrorFetch();
-    const { findByText } = renderWithQueryClient(<LearnPage />);
+    const { findByText } = renderWithQueryClient(<LearnPageComponent />);
 
     expect(await findByText(/failed/i)).toBeInTheDocument();
   });
 
   it("shows the current question when loaded successfully", async () => {
     mockSuccessfulFetch();
-    const { findByText } = renderWithQueryClient(<LearnPage />);
+    const { findByText } = renderWithQueryClient(<LearnPageComponent />);
 
     expect(await findByText(/the cat/i)).toBeInTheDocument();
   });
 
   it("shows a next button when not on the last question", async () => {
     mockSuccessfulFetch();
-    const { findByText } = renderWithQueryClient(<LearnPage />);
+    const { findByText } = renderWithQueryClient(<LearnPageComponent />);
 
     expect(await findByText(/next/i)).toBeInTheDocument();
   });
 
   it("advances to the next question when Next button is clicked", async () => {
     mockSuccessfulFetch();
-    const { findByText } = renderWithQueryClient(<LearnPage />);
+    const { findByText } = renderWithQueryClient(<LearnPageComponent />);
 
     const nextBtn = await findByText(/next/i);
     fireEvent.click(nextBtn);
@@ -63,7 +63,7 @@ describe("LearnPage", () => {
 
   it("shows a finish button on the last question", async () => {
     mockSuccessfulFetch();
-    const { findByText } = renderWithQueryClient(<LearnPage />);
+    const { findByText } = renderWithQueryClient(<LearnPageComponent />);
 
     await navigateToLastQuestion(findByText);
 
@@ -72,7 +72,7 @@ describe("LearnPage", () => {
 
   it("redirects when finish button is clicked", async () => {
     mockSuccessfulFetch();
-    const { findByText } = renderWithQueryClient(<LearnPage />);
+    const { findByText } = renderWithQueryClient(<LearnPageComponent />);
 
     await navigateToLastQuestion(findByText);
     const finishBtn = await findByText(/finish/i);
@@ -83,7 +83,7 @@ describe("LearnPage", () => {
 
   it("focuses the Next button after answer submission", async () => {
     mockSuccessfulFetch();
-    const { findByRole } = renderWithQueryClient(<LearnPage />);
+    const { findByRole } = renderWithQueryClient(<LearnPageComponent />);
 
     const input = await findByRole("textbox");
     fireEvent.change(input, { target: { value: "stretched" } });
@@ -96,7 +96,7 @@ describe("LearnPage", () => {
 
   it("shows a message when no questions are available", async () => {
     mockEmptyFetch();
-    const { findByText } = renderWithQueryClient(<LearnPage />);
+    const { findByText } = renderWithQueryClient(<LearnPageComponent />);
 
     expect(await findByText(/no questions available/i)).toBeInTheDocument();
   });

--- a/lingetic-nextjs-frontend/app/languages/learn/[language]/page.tsx
+++ b/lingetic-nextjs-frontend/app/languages/learn/[language]/page.tsx
@@ -27,7 +27,8 @@ export default function LearnPage() {
   );
 }
 
-function LearnPageComponent() {
+// exported to allow unit testing; not meant to be used elsewhere
+export function LearnPageComponent() {
   const { language } = useParams<LearnPageParams>();
   assert(language?.trim()?.length > 0, "language is required");
 

--- a/lingetic-nextjs-frontend/jest.setup.js
+++ b/lingetic-nextjs-frontend/jest.setup.js
@@ -1,1 +1,12 @@
+import { useAuth } from '@clerk/nextjs';
 import '@testing-library/jest-dom';
+
+jest.mock('@clerk/nextjs', () => ({
+  useAuth: jest.fn(),
+}));
+
+useAuth.mockReturnValue({
+  isSignedIn: true,
+  isLoaded: true,
+  getToken: jest.fn().mockResolvedValue('mock-token'),
+});


### PR DESCRIPTION
These tests were written before authentication was
introduced. To make these tests pass:
* useAuth has been mocked to always assume authenticated.
* LearnPageComponent is used which is shown when authenticated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated component naming to improve internal clarity.
- **Tests**
  - Adjusted internal references and enhanced authentication mocks to ensure a more robust testing environment.

These internal improvements maintain current functionality while strengthening the foundation for future enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->