### PR TITLE
Add qodo to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ replay_pid*
 
 # Other files
 .qodo/*
+.qodo


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Enhanced file exclusion settings by adding the `.qodo` directory to the ignore list, ensuring non-essential files remain untracked for a cleaner project repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->