### PR TITLE
Fix failing test due to text change

### DIFF
--- a/lingetic-nextjs-frontend/__tests__/pages/learn/LearnPage.test.tsx
+++ b/lingetic-nextjs-frontend/__tests__/pages/learn/LearnPage.test.tsx
@@ -27,14 +27,14 @@ describe("LearnPageComponent", () => {
     mockNetworkErrorFetch();
     const { findByText } = renderWithQueryClient(<LearnPageComponent />);
 
-    expect(await findByText(/failed/i)).toBeInTheDocument();
+    expect(await findByText(/oops/i)).toBeInTheDocument();
   });
 
   it("shows error when request resolves unsuccessfully", async () => {
     mockServerErrorFetch();
     const { findByText } = renderWithQueryClient(<LearnPageComponent />);
 
-    expect(await findByText(/failed/i)).toBeInTheDocument();
+    expect(await findByText(/oops/i)).toBeInTheDocument();
   });
 
   it("shows the current question when loaded successfully", async () => {


### PR DESCRIPTION
### **PR Type**
Tests, Bug fix


___

### **Description**
- Updated test assertions to match new error text.

- Fixed failing tests caused by text change in error messages.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LearnPage.test.tsx</strong><dd><code>Adjust test assertions for updated error text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-nextjs-frontend/__tests__/pages/learn/LearnPage.test.tsx

<li>Updated error message assertions in two test cases.<br> <li> Replaced "failed" with "oops" in expected text.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/101/files#diff-2b0a6a311c4c133ca66b9d7d5a66db57d60165c1304fd149ac4ca68cdc962db6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated error messaging during network or server issues to display a more user-friendly notification ("oops") instead of "failed".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->