### PR TITLE
Set JAVA_HOME in shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -13,6 +13,8 @@ pkgs.mkShell {
   ];
 
   shellHook = ''
+    export JAVA_HOME=${pkgs.jdk23.home}
+
     echo "Setting up Docker and Ollama..."
 
     export DOCKER_HOST=unix:///tmp/docker.sock


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added `JAVA_HOME` environment variable in `shell.nix`.

- Improved shell environment setup for Java development.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shell.nix</strong><dd><code>Add JAVA_HOME export to shell.nix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

shell.nix

<li>Added <code>JAVA_HOME</code> export to the shell hook.<br> <li> Enhanced shell environment for Java-related tools.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/108/files#diff-e53dfbfffe62ae3c0b411b3938ccffa9fb6a2ecc565f55785ef8daa756631a6b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the shell environment configuration to automatically set the `JAVA_HOME` variable for Java development. This ensures that tools relying on Java are properly configured without any additional steps for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->