### PR TITLE
Make Learn page a client component

### DIFF
--- a/lingetic-nextjs-frontend/app/languages/learn/[language]/page.tsx
+++ b/lingetic-nextjs-frontend/app/languages/learn/[language]/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { RedirectToSignIn, SignedIn, SignedOut } from "@clerk/nextjs";
 import LearnPageComponent from "./LearnPageComponent";
 


### PR DESCRIPTION
### **User description**
It uses Clerk which defaults to using Next.js middlewares in server
components.


___

### **PR Type**
Enhancement


___

### **Description**
- Converted the Learn page to a client component.

- Added `"use client"` directive to enable client-side rendering.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Added client directive to Learn page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-nextjs-frontend/app/languages/learn/[language]/page.tsx

<li>Added <code>"use client"</code> directive at the top of the file.<br> <li> Ensured compatibility with Clerk's client-side rendering requirements.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/121/files#diff-c3d3b38932fc8d79dee987f7cd30ea5d9e2d2a47ec0558c3865f3c19a1867d2a">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the language learning page configuration to enable seamless client-side interaction for improved responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->