### PR TITLE
Convert renderQuestion into a React component

### DIFF
--- a/lingetic-nextjs-frontend/app/languages/learn/[language]/LearnPageComponent.tsx
+++ b/lingetic-nextjs-frontend/app/languages/learn/[language]/LearnPageComponent.tsx
@@ -9,7 +9,6 @@ import FillInTheBlanks from "@/app/components/questions/FillInTheBlanks/FillInTh
 import type { FillInTheBlanksQuestion, Question } from "@/utilities/api-types";
 import type QuestionProps from "@/app/components/questions/QuestionProps";
 
-
 export default function LearnPageComponent() {
   const { language } = useParams<LearnPageParams>();
   assert(language?.trim()?.length > 0, "language is required");
@@ -87,9 +86,10 @@ export default function LearnPageComponent() {
         </div>
 
         <div className="bg-white rounded-xl shadow-lg p-8 mb-6">
-          {renderQuestion(result.currentQuestion, () =>
-            nextButtonRef.current?.focus()
-          )}
+          <RenderQuestion
+            question={result.currentQuestion}
+            onAnswerSubmit={() => nextButtonRef.current?.focus()}
+          />
         </div>
 
         <div className="flex justify-end">
@@ -112,8 +112,12 @@ type LearnPageParams = {
   language: string;
 };
 
+interface RenderQuestionProps {
+  question: Question;
+  onAnswerSubmit?: () => void;
+}
 
-const renderQuestion = (question: Question, onAnswerSubmit?: () => void) => {
+const RenderQuestion = ({ question, onAnswerSubmit }: RenderQuestionProps) => {
   validateQuestionOrDie(question);
 
   const Component = questionTypeToComponentMap[question.questionType];


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Converted `renderQuestion` function into a React component named `RenderQuestion`.

- Updated `LearnPageComponent` to use the new `RenderQuestion` component.

- Added `RenderQuestionProps` interface for type safety in the new component.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LearnPageComponent.tsx</strong><dd><code>Refactored `renderQuestion` into a React component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-nextjs-frontend/app/languages/learn/[language]/LearnPageComponent.tsx

<li>Replaced <code>renderQuestion</code> function with a new <code>RenderQuestion</code> React <br>component.<br> <li> Updated <code>LearnPageComponent</code> to use the <code>RenderQuestion</code> component.<br> <li> Introduced <code>RenderQuestionProps</code> interface for better type definition.<br> <li> Improved code readability and modularity by using a React component.


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/122/files#diff-73c7ec1e1c797e5fb5355477c0a58b8b06d978b3347fb23480db455dd45afc8d">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the learning interface's question display to use a dedicated component, enhancing modularity and maintainability.

- **Style**
  - Performed minor formatting cleanup for improved code consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->