### PR TITLE
Use URI to register RabbitMQ for tests

### DIFF
--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCaseTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCaseTest.java
@@ -37,15 +37,12 @@ class AttemptQuestionUseCaseTest {
     private static final RabbitMQContainer rabbitmq = new RabbitMQContainer("rabbitmq:4-management");
 
     @DynamicPropertySource
-    static void registerPgProperties(DynamicPropertyRegistry registry) {
+    static void registerPgAndRabbitMQProperties(DynamicPropertyRegistry registry) {
         registry.add("spring.datasource.url", postgres::getJdbcUrl);
         registry.add("spring.datasource.username", postgres::getUsername);
         registry.add("spring.datasource.password", postgres::getPassword);
 
-        registry.add("spring.rabbitmq.host", rabbitmq::getHost);
-        registry.add("spring.rabbitmq.port", rabbitmq::getAmqpPort);
-        registry.add("spring.rabbitmq.username", rabbitmq::getAdminUsername);
-        registry.add("spring.rabbitmq.password", rabbitmq::getAdminPassword);
+        registry.add("spring.rabbitmq.uri", rabbitmq::getAmqpUrl);
     }
 
     @Autowired

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/infra/tasks/RabbitMQTaskQueueTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/infra/tasks/RabbitMQTaskQueueTest.java
@@ -28,10 +28,7 @@ class RabbitMQTaskQueueTest {
         // Disable Flyway migrations since we are not using a database in this test
         registry.add("spring.flyway.enabled", () -> false);
 
-        registry.add("spring.rabbitmq.host", rabbitmq::getHost);
-        registry.add("spring.rabbitmq.port", rabbitmq::getAmqpPort);
-        registry.add("spring.rabbitmq.username", rabbitmq::getAdminUsername);
-        registry.add("spring.rabbitmq.password", rabbitmq::getAdminPassword);
+        registry.add("spring.rabbitmq.uri", rabbitmq::getAmqpUrl);
     }
 
     @Autowired


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Simplified RabbitMQ test configuration by consolidating multiple connection properties into a single URI property in test setups. This streamlines test environment configuration without impacting application features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->