### PR TITLE
Wake up the backend when landing page loads

### DIFF
--- a/lingetic-nextjs-frontend/app/components/landing-page/WakeUpBackend.tsx
+++ b/lingetic-nextjs-frontend/app/components/landing-page/WakeUpBackend.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { wakeUpBackend } from "@/utilities/api";
+import { useEffect } from "react";
+
+export default function WakeUpBackend() {
+  useEffect(() => {
+    wakeUpBackend();
+  }, []);
+
+  return <></>;
+}

--- a/lingetic-nextjs-frontend/app/page.tsx
+++ b/lingetic-nextjs-frontend/app/page.tsx
@@ -1,10 +1,12 @@
 import HeroSection from "./components/landing-page/HeroSection";
+import WakeUpBackend from "./components/landing-page/WakeUpBackend";
 import { languages } from "./languages/constants";
 
 export default function Home() {
   return (
     <main className="min-h-screen">
       <HeroSection languages={languages} />
+      <WakeUpBackend />
     </main>
   );
 }

--- a/lingetic-nextjs-frontend/utilities/api.ts
+++ b/lingetic-nextjs-frontend/utilities/api.ts
@@ -14,6 +14,12 @@ async function fetchOrThrow<T>(url: string, options?: RequestInit): Promise<T> {
   throw new Error(response.statusText);
 }
 
+export async function wakeUpBackend(): Promise<void> {
+  await fetchOrThrow(
+    `${process.env.NEXT_PUBLIC_API_BASE_URL}/health-service/wakeup`
+  );
+}
+
 export async function attemptQuestion<T extends AttemptResponse>(
   attemptRequest: AttemptRequest,
   getToken: () => Promise<string | null>

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/HealthService/infra/HTTP/HealthServiceController.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/HealthService/infra/HTTP/HealthServiceController.java
@@ -1,0 +1,15 @@
+package com.munetmo.lingetic.HealthService.infra.HTTP;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/health-service")
+public class HealthServiceController {
+    @GetMapping("/wakeup")
+    public ResponseEntity<String> wakeup() {
+        return ResponseEntity.ok("{\"status\": \"OK\"}");
+    }
+}

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/infra/auth/SecurityConfig.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/infra/auth/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/health-service/wakeup").permitAll()
                         .requestMatchers("/language-test-service/questions/review").permitAll()
                         .anyRequest().authenticated())
                 .exceptionHandling(exception -> exception.authenticationEntryPoint(unauthorizedHandler()))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a mechanism to automatically wake up the backend service when the home page loads, improving initial responsiveness.
	- Introduced a backend health check endpoint to support this functionality.
- **Bug Fixes**
	- Ensured the new health check endpoint is accessible without authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->