### PR TITLE
Add script to upload to R2

### DIFF
--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "aiofiles>=24.1.0",
     "pdf2image>=1.17.0",
     "gtts>=2.5.4",
+    "boto3>=1.37.37",
 ]
 
 [tool.ruff]

--- a/scripts/scripts/__init__.py
+++ b/scripts/scripts/__init__.py
@@ -7,6 +7,7 @@ from . import insert_into_db
 from . import images_to_sentence_jsons
 from . import pdf_to_images
 from . import tts
+from . import upload_to_r2
 
 __all__ = [
     "hello",
@@ -18,4 +19,5 @@ __all__ = [
     "images_to_sentence_jsons",
     "pdf_to_images",
     "tts",
+    "upload_to_r2",
 ]

--- a/scripts/scripts/upload_to_r2.py
+++ b/scripts/scripts/upload_to_r2.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python
+
+from typing import Dict, List, Any, Optional
+import argparse
+import os
+import sys
+import boto3
+from botocore.exceptions import ClientError
+import mimetypes
+import logging
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def generate_object_key(filepath: str, prefix: Optional[str] = None) -> str:
+    """
+    Generate a unique object key for R2 storage based on the file path.
+
+    Args:
+        filepath: Path to the file to be uploaded.
+        prefix: Optional prefix to add to the object key.
+
+    Returns:
+        A unique object key for R2 storage.
+    """
+    filename = os.path.basename(filepath)
+
+    if prefix:
+        prefix = prefix.rstrip("/") + "/"
+        return f"{prefix}{filename}"
+
+    return filename
+
+
+def get_content_type(filepath: str) -> str:
+    """
+    Determine the content type of a file.
+
+    Args:
+        filepath: Path to the file.
+
+    Returns:
+        The content type of the file.
+    """
+    content_type, _ = mimetypes.guess_type(filepath)
+    return content_type or "application/octet-stream"
+
+
+def create_r2_client(
+    account_id: str, access_key_id: str, secret_access_key: str
+) -> boto3.client:
+    """
+    Create a Cloudflare R2 client using boto3.
+
+    Args:
+        account_id: Cloudflare account ID.
+        access_key_id: R2 access key ID.
+        secret_access_key: R2 secret access key.
+
+    Returns:
+        A boto3 S3 client configured for Cloudflare R2.
+    """
+    return boto3.client(
+        service_name="s3",
+        endpoint_url=f"https://{account_id}.r2.cloudflarestorage.com",
+        aws_access_key_id=access_key_id,
+        aws_secret_access_key=secret_access_key,
+        region_name="auto",  # R2 uses 'auto' as the region
+    )
+
+
+def upload_file(
+    client: boto3.client, filepath: str, bucket_name: str, object_key: str
+) -> bool:
+    """
+    Upload a file to Cloudflare R2.
+
+    Args:
+        client: Boto3 S3 client configured for R2.
+        filepath: Path to the file to be uploaded.
+        bucket_name: Name of the R2 bucket.
+        object_key: Key for the object in R2 storage.
+
+    Returns:
+        True if the upload was successful, False otherwise.
+    """
+    try:
+        content_type = get_content_type(filepath)
+
+        with open(filepath, "rb") as file:
+            client.put_object(
+                Bucket=bucket_name,
+                Key=object_key,
+                Body=file,
+                ContentType=content_type,
+            )
+        return True
+
+    except ClientError as e:
+        logger.error(f"Error uploading {filepath}: {e}")
+        return False
+
+    except Exception as e:
+        logger.error(f"Unexpected error uploading {filepath}: {e}")
+        return False
+
+
+def process_directory(
+    client: boto3.client,
+    directory: str,
+    bucket_name: str,
+    prefix: Optional[str] = None,
+    recursive: bool = False,
+) -> Dict[str, List[Any]]:
+    """
+    Process a directory and upload files to R2.
+
+    Args:
+        client: Boto3 S3 client configured for R2.
+        directory: Directory containing files to upload.
+        bucket_name: Name of the R2 bucket.
+        prefix: Optional prefix for object keys.
+        recursive: If True, process subdirectories recursively.
+
+    Returns:
+        A dictionary with lists of successful and failed uploads.
+    """
+    if not os.path.exists(directory):
+        logger.error(f"Directory '{directory}' not found")
+        sys.exit(1)
+
+    if not os.path.isdir(directory):
+        logger.error(f"'{directory}' is not a directory")
+        sys.exit(1)
+
+    results = {"successful": [], "failed": []}
+
+    for root, dirs, files in os.walk(directory):
+        if not recursive and root != directory:
+            continue
+
+        for filename in files:
+            filepath = os.path.join(root, filename)
+
+            relative_path = os.path.relpath(filepath, directory)
+            dir_part = os.path.dirname(relative_path)
+
+            if prefix and dir_part and recursive:
+                full_prefix = f"{prefix.rstrip('/')}/{dir_part}"
+            elif prefix:
+                full_prefix = prefix
+            elif dir_part and recursive:
+                full_prefix = dir_part
+            else:
+                full_prefix = None
+
+            object_key = generate_object_key(filepath, full_prefix)
+
+            if upload_file(client, filepath, bucket_name, object_key):
+                results["successful"].append(
+                    {"file": filepath, "object_key": object_key}
+                )
+                logger.info(f"Uploaded: {filepath} -> {object_key}")
+            else:
+                results["failed"].append(filepath)
+                logger.warning(f"Failed to upload: {filepath}")
+
+    return results
+
+
+def main(
+    directory: str,
+    bucket_name: str,
+    account_id: str,
+    access_key_id: str,
+    secret_access_key: str,
+    prefix: Optional[str] = None,
+    recursive: bool = False,
+    verbose: bool = False,
+) -> None:
+    """
+    Main function to upload files from a directory to Cloudflare R2.
+
+    Args:
+        directory: Directory containing files to upload.
+        bucket_name: Name of the R2 bucket.
+        account_id: Cloudflare account ID.
+        access_key_id: R2 access key ID.
+        secret_access_key: R2 secret access key.
+        prefix: Optional prefix for object keys.
+        recursive: If True, process subdirectories recursively.
+        verbose: If True, enable verbose logging.
+    """
+    if verbose:
+        logger.setLevel(logging.DEBUG)
+
+    client = create_r2_client(account_id, access_key_id, secret_access_key)
+
+    results = process_directory(
+        client, directory, bucket_name, prefix, recursive
+    )
+
+    logger.info(
+        f"Upload complete: {len(results['successful'])} successful, {len(results['failed'])} failed"
+    )
+
+    if results["failed"]:
+        logger.warning("Failed uploads:")
+        for filepath in results["failed"]:
+            logger.warning(f"  - {filepath}")
+
+
+def get_parser() -> argparse.ArgumentParser:
+    """
+    Create and configure the argument parser for the script.
+
+    Returns:
+        An ArgumentParser object configured with the script's arguments.
+    """
+    parser = argparse.ArgumentParser(
+        description="Upload files from a directory to Cloudflare R2 storage."
+    )
+    parser.add_argument(
+        "-d",
+        "--directory",
+        required=True,
+        help="Directory containing files to upload.",
+    )
+    parser.add_argument(
+        "-b",
+        "--bucket-name",
+        default="lingetic-speech-recordings",
+        help="Name of the R2 bucket.",
+    )
+    parser.add_argument(
+        "-a", "--account-id", required=True, help="Cloudflare account ID."
+    )
+    parser.add_argument(
+        "-k", "--access-key-id", required=True, help="R2 access key ID."
+    )
+    parser.add_argument(
+        "-s", "--secret-access-key", required=True, help="R2 secret access key."
+    )
+    parser.add_argument(
+        "-p", "--prefix", help="Optional prefix for object keys in R2."
+    )
+    parser.add_argument(
+        "-r",
+        "--recursive",
+        action="store_true",
+        help="Recursively process subdirectories.",
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Enable verbose logging."
+    )
+
+    return parser
+
+
+if __name__ == "__main__":
+    parser = get_parser()
+    args = parser.parse_args()
+
+    main(
+        directory=args.directory,
+        bucket_name=args.bucket_name,
+        account_id=args.account_id,
+        access_key_id=args.access_key_id,
+        secret_access_key=args.secret_access_key,
+        prefix=args.prefix,
+        recursive=args.recursive,
+        verbose=args.verbose,
+    )

--- a/scripts/uv.lock
+++ b/scripts/uv.lock
@@ -35,6 +35,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.37.37"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/8c/2ca661db6c9e591d9dc46149b43a91385283c852436ccba62e199643e196/boto3-1.37.37.tar.gz", hash = "sha256:752d31105a45e3e01c8c68471db14ae439990b75a35e72b591ca528e2575b28f", size = 111666 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/5f/032d93e74949222ffbfbc3270f29a3ee423fe648de8a31c49cce0cbb0a09/boto3-1.37.37-py3-none-any.whl", hash = "sha256:d125cb11e22817f7a2581bade4bf7b75247b401888890239ceb5d3e902ccaf38", size = 139917 },
+]
+
+[[package]]
+name = "botocore"
+version = "1.37.37"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/d0/70969515e3ae8ff0fcccf22827d5d131bc7b8729331127415cf8f2861d63/botocore-1.37.37.tar.gz", hash = "sha256:3eadde6fed95c4cb469cc39d1c3558528b7fa76d23e7e16d4bddc77250431a64", size = 13828530 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/17/602915b29cb695e1e66f65e33b1026f1534e49975d99ea4e32e58d963542/botocore-1.37.37-py3-none-any.whl", hash = "sha256:eb730ff978f47c02f0c8ed07bccdc0db6d8fa098ed32ac31bee1da0e9be480d1", size = 13495584 },
+]
+
+[[package]]
 name = "cachetools"
 version = "5.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -197,6 +225,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256 },
 ]
 
 [[package]]
@@ -368,6 +405,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.3"
 source = { registry = "https://pypi.org/simple" }
@@ -420,11 +469,24 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.11.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/2b/5c9562795c2eb2b5f63536961754760c25bf0f34af93d36aa28dea2fb303/s3transfer-0.11.5.tar.gz", hash = "sha256:8c8aad92784779ab8688a61aefff3e28e9ebdce43142808eaa3f0b0f402f68b7", size = 149107 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/39/13402e323666d17850eca87e4cd6ecfcf9fd7809cac9efdcce10272fc29d/s3transfer-0.11.5-py3-none-any.whl", hash = "sha256:757af0f2ac150d3c75bc4177a32355c3862a98d20447b69a0161812992fe0bd4", size = 84782 },
+]
+
+[[package]]
 name = "scripts"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },
+    { name = "boto3" },
     { name = "google-genai" },
     { name = "gtts" },
     { name = "ollama" },
@@ -439,6 +501,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "aiofiles", specifier = ">=24.1.0" },
+    { name = "boto3", specifier = ">=1.37.37" },
     { name = "google-genai", specifier = ">=1.8.0" },
     { name = "gtts", specifier = ">=2.5.4" },
     { name = "ollama", specifier = ">=0.4.7" },
@@ -448,6 +511,15 @@ requires-dist = [
     { name = "ruff", specifier = ">=0.9.9" },
     { name = "tenacity", specifier = ">=9.0.0" },
     { name = "uuid", specifier = ">=1.30" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
 ]
 
 [[package]]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a command-line tool for uploading files or directories to Cloudflare R2 storage with options for recursion, custom prefixes, and detailed logging.

- **Chores**
  - Added a new dependency requirement for `boto3` (version 1.37.37 or higher).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->