### PR TITLE
Move language modeling to a separate service

### DIFF
--- a/lingetic-spring-backend/config/application.properties
+++ b/lingetic-spring-backend/config/application.properties
@@ -1,6 +1,8 @@
 spring.application.name=lingetic
 server.port=8000
 
+app.environment=${ENVIRONMENT}
+
 spring.web.cors.allowed-origins=${FRONTEND_URL}
 spring.main.allow-circular-references=true
 

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/Language.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/Language.java
@@ -1,4 +1,4 @@
-package com.munetmo.lingetic.LanguageTestService.Entities;
+package com.munetmo.lingetic.LanguageService.Entities;
 
 public enum Language {
     DummyLanguage,

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/EnglishLanguageModel.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/EnglishLanguageModel.java
@@ -1,6 +1,6 @@
-package com.munetmo.lingetic.LanguageTestService.Entities.LanguageModels;
+package com.munetmo.lingetic.LanguageService.Entities.LanguageModels;
 
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 
 import java.util.Arrays;
 import java.util.Locale;

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/FrenchLanguageModel.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/FrenchLanguageModel.java
@@ -1,6 +1,6 @@
-package com.munetmo.lingetic.LanguageTestService.Entities.LanguageModels;
+package com.munetmo.lingetic.LanguageService.Entities.LanguageModels;
 
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 
 import java.util.Arrays;
 import java.util.Locale;

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/LanguageModel.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/LanguageModel.java
@@ -1,6 +1,6 @@
-package com.munetmo.lingetic.LanguageTestService.Entities.LanguageModels;
+package com.munetmo.lingetic.LanguageService.Entities.LanguageModels;
 
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import com.munetmo.lingetic.lib.Utilities;
 
 import java.util.Map;

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/TurkishLanguageModel.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/TurkishLanguageModel.java
@@ -1,6 +1,6 @@
-package com.munetmo.lingetic.LanguageTestService.Entities.LanguageModels;
+package com.munetmo.lingetic.LanguageService.Entities.LanguageModels;
 
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 
 import java.util.Arrays;
 import java.util.Locale;

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/Token.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/Token.java
@@ -1,0 +1,4 @@
+package com.munetmo.lingetic.LanguageService.Entities;
+
+public class Token {
+}

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/infra/HTTP/LanguageServiceController.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/infra/HTTP/LanguageServiceController.java
@@ -1,0 +1,16 @@
+package com.munetmo.lingetic.LanguageService.infra.HTTP;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/language-service")
+@ConditionalOnProperty(name = "app.environment", havingValue = "development")
+public class LanguageServiceController {
+    @GetMapping
+    public String hello() {
+        return "Hello";
+    }
+}

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/FillInTheBlanksQuestionDTO.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/FillInTheBlanksQuestionDTO.java
@@ -1,6 +1,6 @@
 package com.munetmo.lingetic.LanguageTestService.DTOs.Question;
 
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
 import org.jspecify.annotations.Nullable;
 

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/QuestionDTO.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/QuestionDTO.java
@@ -1,6 +1,6 @@
 package com.munetmo.lingetic.LanguageTestService.DTOs.Question;
 
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.FillInTheBlanksQuestion;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.Question;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/QuestionList.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/QuestionList.java
@@ -1,5 +1,7 @@
 package com.munetmo.lingetic.LanguageTestService.Entities;
 
+import com.munetmo.lingetic.LanguageService.Entities.Language;
+
 public class QuestionList {
     private final String id;
     private final String name;

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/QuestionReview.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/QuestionReview.java
@@ -1,5 +1,7 @@
 package com.munetmo.lingetic.LanguageTestService.Entities;
 
+import com.munetmo.lingetic.LanguageService.Entities.Language;
+
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestion.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestion.java
@@ -5,8 +5,8 @@ import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests.Fil
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.AttemptResponse;
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.FillInTheBlanksAttemptResponse;
 import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
-import com.munetmo.lingetic.LanguageTestService.Entities.LanguageModels.LanguageModel;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.LanguageModels.LanguageModel;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Map;

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/Question.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/Question.java
@@ -2,7 +2,7 @@ package com.munetmo.lingetic.LanguageTestService.Entities.Questions;
 
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests.AttemptRequest;
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.AttemptResponse;
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 
 import java.util.Map;
 

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Repositories/QuestionListRepository.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Repositories/QuestionListRepository.java
@@ -1,8 +1,7 @@
 package com.munetmo.lingetic.LanguageTestService.Repositories;
 
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.QuestionList;
-import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionListNotFoundException;
 import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionListWithIDAlreadyExistsException;
 
 import java.util.List;

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Repositories/QuestionRepository.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Repositories/QuestionRepository.java
@@ -1,6 +1,6 @@
 package com.munetmo.lingetic.LanguageTestService.Repositories;
 
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.Question;
 import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionNotFoundException;
 import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionWithIDAlreadyExistsException;

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Repositories/QuestionReviewRepository.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Repositories/QuestionReviewRepository.java
@@ -1,6 +1,6 @@
 package com.munetmo.lingetic.LanguageTestService.Repositories;
 
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.QuestionReview;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.Question;
 

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/UseCases/GetQuestionListsForLanguageUseCase.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/UseCases/GetQuestionListsForLanguageUseCase.java
@@ -1,6 +1,6 @@
 package com.munetmo.lingetic.LanguageTestService.UseCases;
 
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.QuestionList;
 import com.munetmo.lingetic.LanguageTestService.Repositories.QuestionListRepository;
 

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/UseCases/TakeRegularTestUseCase.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/UseCases/TakeRegularTestUseCase.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.munetmo.lingetic.LanguageTestService.DTOs.Question.*;
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Repositories.QuestionRepository;
 import com.munetmo.lingetic.LanguageTestService.Repositories.QuestionReviewRepository;
 

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/HTTP/LanguageTestServiceController.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/HTTP/LanguageTestServiceController.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests.AttemptRequest;
 import com.munetmo.lingetic.LanguageTestService.DTOs.TaskPayloads.GenericTaskPayloadWrapper;
 import com.munetmo.lingetic.LanguageTestService.DTOs.TaskPayloads.QuestionReviewProcessingPayload;
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.QuestionList;
 import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionNotFoundException;
 import io.jsonwebtoken.Claims;

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/Repositories/Postgres/QuestionListPostgresRepository.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/Repositories/Postgres/QuestionListPostgresRepository.java
@@ -1,6 +1,6 @@
 package com.munetmo.lingetic.LanguageTestService.infra.Repositories.Postgres;
 
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.QuestionList;
 import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionListWithIDAlreadyExistsException;
 import com.munetmo.lingetic.LanguageTestService.Repositories.QuestionListRepository;

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/Repositories/Postgres/QuestionPostgresRepository.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/Repositories/Postgres/QuestionPostgresRepository.java
@@ -3,7 +3,7 @@ package com.munetmo.lingetic.LanguageTestService.infra.Repositories.Postgres;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.Question;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
 import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionNotFoundException;

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/Repositories/Postgres/QuestionReviewPostgresRepository.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/infra/Repositories/Postgres/QuestionReviewPostgresRepository.java
@@ -1,6 +1,6 @@
 package com.munetmo.lingetic.LanguageTestService.infra.Repositories.Postgres;
 
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.QuestionReview;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.Question;
 import com.munetmo.lingetic.LanguageTestService.Repositories.QuestionReviewRepository;

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/infra/auth/SecurityConfig.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/infra/auth/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/language-service/**").permitAll()
                         .requestMatchers("/health-service/wakeup").permitAll()
                         .requestMatchers("/language-test-service/questions/review").permitAll()
                         .anyRequest().authenticated())

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/EnglishLanguageModelTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/EnglishLanguageModelTest.java
@@ -1,6 +1,7 @@
-package com.munetmo.lingetic.LanguageTestService.Entities.LanguageModels;
+package com.munetmo.lingetic.LanguageService.Entities.LanguageModels;
 
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.LanguageModels.EnglishLanguageModel;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/FrenchLanguageModelTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/FrenchLanguageModelTest.java
@@ -1,6 +1,7 @@
-package com.munetmo.lingetic.LanguageTestService.Entities.LanguageModels;
+package com.munetmo.lingetic.LanguageService.Entities.LanguageModels;
 
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.LanguageModels.FrenchLanguageModel;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/TurkishLanguageModelTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/TurkishLanguageModelTest.java
@@ -1,6 +1,7 @@
-package com.munetmo.lingetic.LanguageTestService.Entities.LanguageModels;
+package com.munetmo.lingetic.LanguageService.Entities.LanguageModels;
 
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.LanguageModels.TurkishLanguageModel;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/FillInTheBlanksQuestionDTOTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/FillInTheBlanksQuestionDTOTest.java
@@ -1,6 +1,6 @@
 package com.munetmo.lingetic.LanguageTestService.DTOs.Question;
 
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/QuestionDTOTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/QuestionDTOTest.java
@@ -1,6 +1,6 @@
 package com.munetmo.lingetic.LanguageTestService.DTOs.Question;
 
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.FillInTheBlanksQuestion;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
 import com.munetmo.lingetic.lib.HashUtils;

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/QuestionListTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/QuestionListTest.java
@@ -2,6 +2,7 @@ package com.munetmo.lingetic.LanguageTestService.Entities;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import org.junit.jupiter.api.Test;
 
 class QuestionListTest {

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/QuestionReviewTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/QuestionReviewTest.java
@@ -6,6 +6,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import org.junit.jupiter.api.Test;
 
 class QuestionReviewTest {

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestionTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestionTest.java
@@ -3,7 +3,7 @@ package com.munetmo.lingetic.LanguageTestService.Entities.Questions;
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests.FillInTheBlanksAttemptRequest;
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.FillInTheBlanksAttemptResponse;
 import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCaseTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/AttemptQuestionUseCaseTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests.FillInTheBlanksAttemptRequest;
 import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.AttemptResponse;
 import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.QuestionList;
 import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionNotFoundException;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.FillInTheBlanksQuestion;

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/GetQuestionListsForLanguageUseCaseTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/GetQuestionListsForLanguageUseCaseTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.List;
 import java.util.UUID;
 
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.QuestionList;
 import com.munetmo.lingetic.LanguageTestService.infra.Repositories.Postgres.QuestionListPostgresRepository;
 import org.junit.jupiter.api.BeforeEach;

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/ReviewQuestionUseCaseTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/ReviewQuestionUseCaseTest.java
@@ -2,7 +2,7 @@ package com.munetmo.lingetic.LanguageTestService.UseCases;
 
 import com.munetmo.lingetic.LanguageTestService.DTOs.TaskPayloads.QuestionReviewProcessingPayload;
 import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.QuestionList;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.FillInTheBlanksQuestion;
 import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionNotFoundException;

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/TakeRegularTestUseCaseTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/UseCases/TakeRegularTestUseCaseTest.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 import java.util.stream.IntStream;
 
 import com.munetmo.lingetic.LanguageTestService.DTOs.Question.QuestionDTO;
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.FillInTheBlanksQuestion;
 import com.munetmo.lingetic.LanguageTestService.Entities.QuestionList;
 import com.munetmo.lingetic.LanguageTestService.infra.Repositories.Postgres.QuestionListPostgresRepository;

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/infra/Repositories/Postgres/QuestionListPostgresRepositoryTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/infra/Repositories/Postgres/QuestionListPostgresRepositoryTest.java
@@ -1,6 +1,6 @@
 package com.munetmo.lingetic.LanguageTestService.infra.Repositories.Postgres;
 
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.QuestionList;
 import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionListWithIDAlreadyExistsException;
 import org.junit.jupiter.api.*;

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/infra/Repositories/Postgres/QuestionPostgresRepositoryTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/infra/Repositories/Postgres/QuestionPostgresRepositoryTest.java
@@ -1,6 +1,6 @@
 package com.munetmo.lingetic.LanguageTestService.infra.Repositories.Postgres;
 
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.FillInTheBlanksQuestion;
 import com.munetmo.lingetic.LanguageTestService.Entities.QuestionList;
 import com.munetmo.lingetic.LanguageTestService.Exceptions.QuestionNotFoundException;

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/infra/Repositories/Postgres/QuestionReviewPostgresRepositoryTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/infra/Repositories/Postgres/QuestionReviewPostgresRepositoryTest.java
@@ -1,6 +1,6 @@
 package com.munetmo.lingetic.LanguageTestService.infra.Repositories.Postgres;
 
-import com.munetmo.lingetic.LanguageTestService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.QuestionReview;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.FillInTheBlanksQuestion;
 import com.munetmo.lingetic.LanguageTestService.Entities.QuestionList;


### PR DESCRIPTION
This allows other parts of Lingetic not written
in Java to use these.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new REST endpoint at `/language-service` that returns "Hello" when accessed, available only in the development environment.

- **Chores**
  - Updated internal configuration to support environment-specific settings.
  - Standardized package and import paths for language-related classes throughout the codebase.
  - Allowed unauthenticated access to the `/language-service/**` endpoints in security settings.

- **Tests**
  - Updated test files to align with the new package structure for language entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->