### PR TITLE
Add method to tokenize sentences

### DIFF
--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/EnglishLanguageModel.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/EnglishLanguageModel.java
@@ -3,16 +3,18 @@ package com.munetmo.lingetic.LanguageService.Entities.LanguageModels;
 import com.munetmo.lingetic.LanguageService.Entities.Language;
 import com.munetmo.lingetic.LanguageService.Entities.Token;
 import com.munetmo.lingetic.LanguageService.Entities.TokenType;
+import com.munetmo.lingetic.LanguageService.Entities.LanguageModels.LatinScriptLanguageModelHelper;
 import org.jspecify.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
 public final class EnglishLanguageModel implements LanguageModel {
-    private static final String terminalPunctuation = ".?!;,:";
-    private static final String surroundingPunctuation = "\'\"";
+    private final LatinScriptLanguageModelHelper helper;
+
+    public EnglishLanguageModel() {
+        this.helper = new LatinScriptLanguageModelHelper(Locale.ENGLISH);
+    }
 
     @Override
     public Language getLanguage() {
@@ -21,77 +23,11 @@ public final class EnglishLanguageModel implements LanguageModel {
 
     @Override
     public boolean areEquivalent(String s1, String s2) {
-        var normalized1 = normalizeString(s1);
-        var normalized2 = normalizeString(s2);
-
-        return normalized1.equals(normalized2);
-    }
-
-    private String normalizeString(String input) {
-        var words = input.split("\\s+");
-        var normalizedWords = Arrays.stream(words)
-                .map(w -> w.trim().toLowerCase(Locale.ENGLISH))
-                .map(w -> w.replaceAll("^[^a-z0-9]+|[^a-z0-9]+$", ""))
-                .filter(w -> !w.isBlank());
-
-        var normalized = String.join(" ", normalizedWords.toList());
-
-        return normalized;
+        return helper.areEquivalent(s1, s2);
     }
 
     @Override
     public List<Token> tokenize(String input) {
-        var tokens = new ArrayList<Token>();
-
-        if (input.isBlank()) {
-            return tokens;
-        }
-
-        var parts = input.split("\\s+");
-        for (var part : parts) {
-            var firstChar = part.substring(0, 1);
-            if (surroundingPunctuation.contains(firstChar)) {
-                tokens.add(new Token(TokenType.Punctuation, firstChar));
-                part = part.substring(1);
-            }
-
-            if (part.isBlank()) {
-                continue;
-            }
-
-            @Nullable Token lastToken = null;
-            var lastChar = part.substring(part.length() - 1);
-            if (surroundingPunctuation.contains(lastChar) || terminalPunctuation.contains(lastChar)) {
-                lastToken = new Token(TokenType.Punctuation, lastChar);
-                part = part.substring(0, part.length() - 1);
-            }
-
-            if (part.isBlank()) {
-                tokens.add(lastToken);
-                continue;
-            }
-
-            if (containsLetter(part)) {
-                tokens.add(new Token(TokenType.Word, part));
-            } else if (containsDigit(part)) {
-                tokens.add(new Token(TokenType.Number, part));
-            } else {
-                tokens.add(new Token(TokenType.Punctuation, part));
-            }
-
-            if (lastToken != null) {
-                tokens.add(lastToken);
-            }
-        }
-
-        return tokens;
-    }
-
-    private boolean containsLetter(String input) {
-        return input.chars().anyMatch(Character::isLetter);
-    }
-
-    private boolean containsDigit(String input) {
-        return input.chars().anyMatch(Character::isDigit);
+        return helper.tokenize(input);
     }
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/FrenchLanguageModel.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/FrenchLanguageModel.java
@@ -2,18 +2,16 @@ package com.munetmo.lingetic.LanguageService.Entities.LanguageModels;
 
 import com.munetmo.lingetic.LanguageService.Entities.Language;
 import com.munetmo.lingetic.LanguageService.Entities.Token;
-import com.munetmo.lingetic.LanguageService.Entities.TokenType;
-import org.jspecify.annotations.Nullable;
-
-import java.util.ArrayList;
-import java.util.Arrays;
+import com.munetmo.lingetic.LanguageService.Entities.LanguageModels.LatinScriptLanguageModelHelper;
 import java.util.List;
 import java.util.Locale;
 
 public final class FrenchLanguageModel implements LanguageModel {
-    private static final String terminalPunctuation = ".?!;,:";
-    private static final String surroundingPunctuation = "\'\"«»";
-    private static final String frenchSpecificCharacters = "àâäæçéèêëîïôœùûüÿ";
+    private final LatinScriptLanguageModelHelper helper;
+
+    public FrenchLanguageModel() {
+        this.helper = new LatinScriptLanguageModelHelper(Locale.FRANCE);
+    }
 
     @Override
     public Language getLanguage() {
@@ -22,78 +20,11 @@ public final class FrenchLanguageModel implements LanguageModel {
 
     @Override
     public boolean areEquivalent(String s1, String s2) {
-        var normalized1 = normalizeString(s1);
-        var normalized2 = normalizeString(s2);
-
-        return normalized1.equals(normalized2);
-    }
-
-    private String normalizeString(String input) {
-        var regex = String.format("^[^a-z0-9%s]+|[^a-z0-9%s]+$", frenchSpecificCharacters,
-                frenchSpecificCharacters);
-
-        var words = input.split("\\s+");
-        var normalizedWords = Arrays.stream(words)
-                .map(w -> w.trim().toLowerCase(Locale.FRANCE))
-                .map(w -> w.replaceAll(regex, ""))
-                .filter(w -> !w.isBlank());
-
-        return String.join(" ", normalizedWords.toList());
+        return helper.areEquivalent(s1, s2);
     }
 
     @Override
     public List<Token> tokenize(String input) {
-        var tokens = new ArrayList<Token>();
-
-        if (input.isBlank()) {
-            return tokens;
-        }
-
-        var parts = input.split("\\s+");
-        for (var part : parts) {
-            var firstChar = part.substring(0, 1);
-            if (surroundingPunctuation.contains(firstChar)) {
-                tokens.add(new Token(TokenType.Punctuation, firstChar));
-                part = part.substring(1);
-            }
-
-            if (part.isBlank()) {
-                continue;
-            }
-
-            @Nullable Token lastToken = null;
-            var lastChar = part.substring(part.length() - 1);
-            if (surroundingPunctuation.contains(lastChar) || terminalPunctuation.contains(lastChar)) {
-                lastToken = new Token(TokenType.Punctuation, lastChar);
-                part = part.substring(0, part.length() - 1);
-            }
-
-            if (part.isBlank()) {
-                tokens.add(lastToken);
-                continue;
-            }
-
-            if (containsLetter(part)) {
-                tokens.add(new Token(TokenType.Word, part));
-            } else if (containsDigit(part)) {
-                tokens.add(new Token(TokenType.Number, part));
-            } else {
-                tokens.add(new Token(TokenType.Punctuation, part));
-            }
-
-            if (lastToken != null) {
-                tokens.add(lastToken);
-            }
-        }
-
-        return tokens;
-    }
-
-    private boolean containsLetter(String input) {
-        return input.chars().anyMatch(Character::isLetter);
-    }
-
-    private boolean containsDigit(String input) {
-        return input.chars().anyMatch(Character::isDigit);
+        return helper.tokenize(input);
     }
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/FrenchLanguageModel.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/FrenchLanguageModel.java
@@ -1,17 +1,24 @@
 package com.munetmo.lingetic.LanguageService.Entities.LanguageModels;
 
 import com.munetmo.lingetic.LanguageService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Token;
+import com.munetmo.lingetic.LanguageService.Entities.TokenType;
+import org.jspecify.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 
 public final class FrenchLanguageModel implements LanguageModel {
+    private static final String terminalPunctuation = ".?!;,:";
+    private static final String surroundingPunctuation = "\'\"«»";
+    private static final String frenchSpecificCharacters = "àâäæçéèêëîïôœùûüÿ";
+
     @Override
     public Language getLanguage() {
         return Language.French;
     }
-
-    private static final String frenchSpecificCharacters = "àâäæçéèêëîïôœùûüÿ";
 
     @Override
     public boolean areEquivalent(String s1, String s2) {
@@ -32,5 +39,61 @@ public final class FrenchLanguageModel implements LanguageModel {
                 .filter(w -> !w.isBlank());
 
         return String.join(" ", normalizedWords.toList());
+    }
+
+    @Override
+    public List<Token> tokenize(String input) {
+        var tokens = new ArrayList<Token>();
+
+        if (input.isBlank()) {
+            return tokens;
+        }
+
+        var parts = input.split("\\s+");
+        for (var part : parts) {
+            var firstChar = part.substring(0, 1);
+            if (surroundingPunctuation.contains(firstChar)) {
+                tokens.add(new Token(TokenType.Punctuation, firstChar));
+                part = part.substring(1);
+            }
+
+            if (part.isBlank()) {
+                continue;
+            }
+
+            @Nullable Token lastToken = null;
+            var lastChar = part.substring(part.length() - 1);
+            if (surroundingPunctuation.contains(lastChar) || terminalPunctuation.contains(lastChar)) {
+                lastToken = new Token(TokenType.Punctuation, lastChar);
+                part = part.substring(0, part.length() - 1);
+            }
+
+            if (part.isBlank()) {
+                tokens.add(lastToken);
+                continue;
+            }
+
+            if (containsLetter(part)) {
+                tokens.add(new Token(TokenType.Word, part));
+            } else if (containsDigit(part)) {
+                tokens.add(new Token(TokenType.Number, part));
+            } else {
+                tokens.add(new Token(TokenType.Punctuation, part));
+            }
+
+            if (lastToken != null) {
+                tokens.add(lastToken);
+            }
+        }
+
+        return tokens;
+    }
+
+    private boolean containsLetter(String input) {
+        return input.chars().anyMatch(Character::isLetter);
+    }
+
+    private boolean containsDigit(String input) {
+        return input.chars().anyMatch(Character::isDigit);
     }
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/LanguageModel.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/LanguageModel.java
@@ -1,14 +1,19 @@
 package com.munetmo.lingetic.LanguageService.Entities.LanguageModels;
 
 import com.munetmo.lingetic.LanguageService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Token;
 import com.munetmo.lingetic.lib.Utilities;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 public sealed interface LanguageModel permits EnglishLanguageModel, FrenchLanguageModel, TurkishLanguageModel {
     Language getLanguage();
 
     boolean areEquivalent(String s1, String s2);
+
+    List<Token> tokenize(String sentence);
 
     static final Map<Language, LanguageModel> languageModelInstances = Map.of(
             Language.English, new EnglishLanguageModel(),

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/LatinScriptLanguageModelHelper.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/LatinScriptLanguageModelHelper.java
@@ -1,0 +1,110 @@
+package com.munetmo.lingetic.LanguageService.Entities.LanguageModels;
+
+import com.munetmo.lingetic.LanguageService.Entities.Token;
+import com.munetmo.lingetic.LanguageService.Entities.TokenType;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+public final class LatinScriptLanguageModelHelper {
+    private static final String TERMINAL_PUNCTUATION = ".?!;,:-";
+    private static final String SPECIFIC_CHARACTERS = "àâäæçéèêëîïôœùûüÿçğıöşü";
+    private static final String SURROUNDING_PUNCTUATION = "'\"«»";
+
+    private static final Pattern LEADING_PUNCTUATION_PATTERN = Pattern.compile(
+            "^([%s%s]+)".formatted(SURROUNDING_PUNCTUATION, TERMINAL_PUNCTUATION));
+    private static final Pattern TRAILING_PUNCTUATION_PATTERN = Pattern.compile(
+            "([%s%s]+)$".formatted(SURROUNDING_PUNCTUATION, TERMINAL_PUNCTUATION));
+
+    private final Locale locale;
+
+    public LatinScriptLanguageModelHelper(Locale locale) {
+        this.locale = locale;
+    }
+
+    public boolean areEquivalent(String s1, String s2) {
+        String n1 = normalize(s1);
+        String n2 = normalize(s2);
+        return n1.equals(n2);
+    }
+
+    public List<Token> tokenize(String input) {
+        List<Token> tokens = new ArrayList<>();
+        if (input.isBlank()) return tokens;
+
+        for (var part : input.split("\\s+")) {
+            if (part.isBlank()) continue;
+
+
+            var leadingPunct = getLeadingPunctuations(part);
+            for (var punct : leadingPunct) {
+                tokens.add(new Token(TokenType.Punctuation, punct));
+            }
+            part = part.substring(leadingPunct.size());
+            if (part.isBlank()) continue;
+
+            var trailingTokens = new ArrayList<Token>();
+            var trailingPunct = getTrailingPunctuations(part);
+            for (var punct : trailingPunct) {
+                trailingTokens.add(new Token(TokenType.Punctuation, punct));
+            }
+            part = part.substring(0, part.length() - trailingPunct.size());
+            if (part.isBlank()) {
+                tokens.addAll(trailingTokens);
+                continue;
+            }
+
+            if (containsLetter(part)) {
+                tokens.add(new Token(TokenType.Word, part));
+            } else if (containsDigit(part)) {
+                tokens.add(new Token(TokenType.Number, part));
+            } else {
+                tokens.add(new Token(TokenType.Punctuation, part));
+            }
+
+            tokens.addAll(trailingTokens);
+        }
+        return tokens;
+    }
+
+    private List<String> getLeadingPunctuations(String input) {
+        var matcher = LEADING_PUNCTUATION_PATTERN.matcher(input);
+        if (matcher.find()) {
+            return List.of(matcher.group(1).split(""));
+        }
+        return List.of();
+    }
+
+    private List<String> getTrailingPunctuations(String input) {
+        var matcher = TRAILING_PUNCTUATION_PATTERN.matcher(input);
+        if (matcher.find()) {
+            return List.of(matcher.group(1).split(""));
+        }
+        return List.of();
+    }
+
+    private String normalize(String input) {
+        var words = input.split("\\s+");
+        var cleaned = Arrays.stream(words)
+                .map(w -> w.trim().toLowerCase(locale))
+                .map(w -> {
+                    String regex = String.format("^[^a-z0-9%s]+|[^a-z0-9%s]+$",
+                            SPECIFIC_CHARACTERS, SPECIFIC_CHARACTERS);
+                    return w.replaceAll(regex, "");
+                })
+                .filter(w -> !w.isBlank());
+        return String.join(" ", cleaned.toList());
+    }
+
+    private boolean containsLetter(String s) {
+        return s.chars().anyMatch(Character::isLetter);
+    }
+
+    private boolean containsDigit(String s) {
+        return s.chars().anyMatch(Character::isDigit);
+    }
+}

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/TurkishLanguageModel.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/TurkishLanguageModel.java
@@ -3,12 +3,11 @@ package com.munetmo.lingetic.LanguageService.Entities.LanguageModels;
 import com.munetmo.lingetic.LanguageService.Entities.Language;
 import com.munetmo.lingetic.LanguageService.Entities.Token;
 import com.munetmo.lingetic.LanguageService.Entities.TokenType;
+import com.munetmo.lingetic.LanguageService.Entities.LanguageModels.LatinScriptLanguageModelHelper;
 import org.jspecify.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Locale;
+import java.util.List;
 
 public final class TurkishLanguageModel implements LanguageModel {
     @Override
@@ -16,90 +15,19 @@ public final class TurkishLanguageModel implements LanguageModel {
         return Language.Turkish;
     }
 
-    private static final String turkishSpecificCharacters = "çğıöşü";
-    private static final String terminalPunctuation = ".?!;,:";
-    private static final String surroundingPunctuation = "\'\"";
+    private final LatinScriptLanguageModelHelper helper;
+
+    public TurkishLanguageModel() {
+        this.helper = new LatinScriptLanguageModelHelper(Locale.forLanguageTag("tr-TR"));
+    }
 
     @Override
     public boolean areEquivalent(String s1, String s2) {
-        var normalized1 = normalizeString(s1);
-        var normalized2 = normalizeString(s2);
-
-        return normalized1.equals(normalized2);
+        return helper.areEquivalent(s1, s2);
     }
 
     @Override
     public List<Token> tokenize(String input) {
-        var tokens = new ArrayList<Token>();
-
-        if (input.isBlank()) {
-            return tokens;
-        }
-
-        var parts = input.split("\\s+");
-        for (var part : parts) {
-            if (part.isBlank()) {
-                continue;
-            }
-
-            var firstChar = part.substring(0, 1);
-            if (surroundingPunctuation.contains(firstChar)) {
-                tokens.add(new Token(TokenType.Punctuation, firstChar));
-                part = part.substring(1);
-            }
-
-            if (part.isBlank()) {
-                continue;
-            }
-
-            @Nullable Token lastToken = null;
-            var lastChar = part.substring(part.length() - 1);
-            if (surroundingPunctuation.contains(lastChar) || terminalPunctuation.contains(lastChar)) {
-                lastToken = new Token(TokenType.Punctuation, lastChar);
-                part = part.substring(0, part.length() - 1);
-            }
-
-            if (part.isBlank()) {
-                tokens.add(lastToken);
-                continue;
-            }
-
-            if (containsLetter(part)) {
-                tokens.add(new Token(TokenType.Word, part));
-            } else if (containsDigit(part)) {
-                tokens.add(new Token(TokenType.Number, part));
-            } else {
-                tokens.add(new Token(TokenType.Punctuation, part));
-            }
-
-            if (lastToken != null) {
-                tokens.add(lastToken);
-            }
-        }
-
-        return tokens;
-    }
-
-    private String normalizeString(String input) {
-        var words = input.split("\\s+");
-        var normalizedWords = Arrays.stream(words)
-                .map(w -> w.trim().toLowerCase(Locale.forLanguageTag("tr-TR")))
-                .map(w -> {
-                    var regex = String.format("^[^a-z0-9%s]+|[^a-z0-9%s]+$", turkishSpecificCharacters,
-                            turkishSpecificCharacters);
-
-                    return w.replaceAll(regex, "");
-                })
-                .filter(w -> !w.isBlank());
-
-        return String.join(" ", normalizedWords.toList());
-    }
-
-    private boolean containsLetter(String input) {
-        return input.chars().anyMatch(Character::isLetter);
-    }
-
-    private boolean containsDigit(String input) {
-        return input.chars().anyMatch(Character::isDigit);
+        return helper.tokenize(input);
     }
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/TurkishLanguageModel.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/TurkishLanguageModel.java
@@ -1,8 +1,13 @@
 package com.munetmo.lingetic.LanguageService.Entities.LanguageModels;
 
 import com.munetmo.lingetic.LanguageService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Token;
+import com.munetmo.lingetic.LanguageService.Entities.TokenType;
+import org.jspecify.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 
 public final class TurkishLanguageModel implements LanguageModel {
@@ -12,6 +17,8 @@ public final class TurkishLanguageModel implements LanguageModel {
     }
 
     private static final String turkishSpecificCharacters = "çğıöşü";
+    private static final String terminalPunctuation = ".?!;,:";
+    private static final String surroundingPunctuation = "\'\"";
 
     @Override
     public boolean areEquivalent(String s1, String s2) {
@@ -19,6 +26,58 @@ public final class TurkishLanguageModel implements LanguageModel {
         var normalized2 = normalizeString(s2);
 
         return normalized1.equals(normalized2);
+    }
+
+    @Override
+    public List<Token> tokenize(String input) {
+        var tokens = new ArrayList<Token>();
+
+        if (input.isBlank()) {
+            return tokens;
+        }
+
+        var parts = input.split("\\s+");
+        for (var part : parts) {
+            if (part.isBlank()) {
+                continue;
+            }
+
+            var firstChar = part.substring(0, 1);
+            if (surroundingPunctuation.contains(firstChar)) {
+                tokens.add(new Token(TokenType.Punctuation, firstChar));
+                part = part.substring(1);
+            }
+
+            if (part.isBlank()) {
+                continue;
+            }
+
+            @Nullable Token lastToken = null;
+            var lastChar = part.substring(part.length() - 1);
+            if (surroundingPunctuation.contains(lastChar) || terminalPunctuation.contains(lastChar)) {
+                lastToken = new Token(TokenType.Punctuation, lastChar);
+                part = part.substring(0, part.length() - 1);
+            }
+
+            if (part.isBlank()) {
+                tokens.add(lastToken);
+                continue;
+            }
+
+            if (containsLetter(part)) {
+                tokens.add(new Token(TokenType.Word, part));
+            } else if (containsDigit(part)) {
+                tokens.add(new Token(TokenType.Number, part));
+            } else {
+                tokens.add(new Token(TokenType.Punctuation, part));
+            }
+
+            if (lastToken != null) {
+                tokens.add(lastToken);
+            }
+        }
+
+        return tokens;
     }
 
     private String normalizeString(String input) {
@@ -34,5 +93,13 @@ public final class TurkishLanguageModel implements LanguageModel {
                 .filter(w -> !w.isBlank());
 
         return String.join(" ", normalizedWords.toList());
+    }
+
+    private boolean containsLetter(String input) {
+        return input.chars().anyMatch(Character::isLetter);
+    }
+
+    private boolean containsDigit(String input) {
+        return input.chars().anyMatch(Character::isDigit);
     }
 }

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/EnglishLanguageModelTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/EnglishLanguageModelTest.java
@@ -204,4 +204,39 @@ class EnglishLanguageModelTest {
         assertEquals(TokenType.Punctuation, tokens.get(5).type());
         assertEquals(".", tokens.get(5).value());
     }
+
+    @Test
+    void shouldHandleConsecutivePunctuationEnding() {
+        var tokens = model.tokenize("What?!");
+
+        assertEquals(3, tokens.size());
+
+        assertEquals(TokenType.Word, tokens.get(0).type());
+        assertEquals("What", tokens.get(0).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(1).type());
+        assertEquals("?", tokens.get(1).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(2).type());
+        assertEquals("!", tokens.get(2).value());
+    }
+
+    @Test
+    void shouldHandleConsecutivePunctuationBeginning() {
+        var tokens = model.tokenize("--Now!");
+
+        assertEquals(4, tokens.size());
+
+        assertEquals(TokenType.Punctuation, tokens.get(0).type());
+        assertEquals("-", tokens.get(0).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(1).type());
+        assertEquals("-", tokens.get(1).value());
+
+        assertEquals(TokenType.Word, tokens.get(2).type());
+        assertEquals("Now", tokens.get(2).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(3).type());
+        assertEquals("!", tokens.get(3).value());
+    }
 }

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/EnglishLanguageModelTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/EnglishLanguageModelTest.java
@@ -1,7 +1,8 @@
 package com.munetmo.lingetic.LanguageService.Entities.LanguageModels;
 
-import com.munetmo.lingetic.LanguageService.Entities.LanguageModels.EnglishLanguageModel;
 import com.munetmo.lingetic.LanguageService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Token;
+import com.munetmo.lingetic.LanguageService.Entities.TokenType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -67,5 +68,140 @@ class EnglishLanguageModelTest {
     @Test
     void areEquivalentShouldHandleNumbers() {
         assertTrue(model.areEquivalent("1234", "  1234 "));
+    }
+
+    @Test
+    void tokenizeShouldTokenizeSimpleSentences() {
+        var tokens = model.tokenize("Hello, world!");
+
+        assertEquals(4, tokens.size());
+
+        assertEquals(TokenType.Word, tokens.get(0).type());
+        assertEquals("Hello", tokens.get(0).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(1).type());
+        assertEquals(",", tokens.get(1).value());
+
+        assertEquals(TokenType.Word, tokens.get(2).type());
+        assertEquals("world", tokens.get(2).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(3).type());
+        assertEquals("!", tokens.get(3).value());
+    }
+
+    @Test
+    void tokenizeShouldKeepPunctuationBetweenLettersAsOneWord() {
+        var tokens = model.tokenize("I'll see you when you've done your work, and I'm free.");
+
+        assertEquals(13, tokens.size());
+
+        assertEquals(TokenType.Word, tokens.get(0).type());
+        assertEquals("I'll", tokens.get(0).value());
+
+        assertEquals(TokenType.Word, tokens.get(1).type());
+        assertEquals("see", tokens.get(1).value());
+
+        assertEquals(TokenType.Word, tokens.get(2).type());
+        assertEquals("you", tokens.get(2).value());
+
+        assertEquals(TokenType.Word, tokens.get(3).type());
+        assertEquals("when", tokens.get(3).value());
+
+        assertEquals(TokenType.Word, tokens.get(4).type());
+        assertEquals("you've", tokens.get(4).value());
+
+        assertEquals(TokenType.Word, tokens.get(5).type());
+        assertEquals("done", tokens.get(5).value());
+
+        assertEquals(TokenType.Word, tokens.get(6).type());
+        assertEquals("your", tokens.get(6).value());
+
+        assertEquals(TokenType.Word, tokens.get(7).type());
+        assertEquals("work", tokens.get(7).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(8).type());
+        assertEquals(",", tokens.get(8).value());
+
+        assertEquals(TokenType.Word, tokens.get(9).type());
+        assertEquals("and", tokens.get(9).value());
+
+        assertEquals(TokenType.Word, tokens.get(10).type());
+        assertEquals("I'm", tokens.get(10).value());
+
+        assertEquals(TokenType.Word, tokens.get(11).type());
+        assertEquals("free", tokens.get(11).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(12).type());
+        assertEquals(".", tokens.get(12).value());
+    }
+
+    @Test
+    void tokenizeShouldTokenizeNumbers() {
+        var tokens = model.tokenize("I'm 10.");
+        assertEquals(3, tokens.size());
+
+        assertEquals(TokenType.Word, tokens.get(0).type());
+        assertEquals("I'm", tokens.get(0).value());
+
+        assertEquals(TokenType.Number, tokens.get(1).type());
+        assertEquals("10", tokens.get(1).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(2).type());
+        assertEquals(".", tokens.get(2).value());
+    }
+
+    @Test
+    void tokenizeShouldTreatNumbersWithPunctuationAsNumbers() {
+        var tokens = model.tokenize("(123) 1+2 4,500 3.14 4#2");
+        assertEquals(5, tokens.size());
+
+        assertEquals(new Token(TokenType.Number, "(123)"), tokens.get(0));
+        assertEquals(new Token(TokenType.Number, "1+2"), tokens.get(1));
+        assertEquals(new Token(TokenType.Number, "4,500"), tokens.get(2));
+        assertEquals(new Token(TokenType.Number, "3.14"), tokens.get(3));
+        assertEquals(new Token(TokenType.Number, "4#2"), tokens.get(4));
+    }
+
+    @Test
+    void tokenizeShouldTreatAMixOfNumbersAndLettersAsWords() {
+        var tokens = model.tokenize("I'm in 10a.");
+        assertEquals(4, tokens.size());
+
+        assertEquals(TokenType.Word, tokens.get(0).type());
+        assertEquals("I'm", tokens.get(0).value());
+
+        assertEquals(TokenType.Word, tokens.get(1).type());
+        assertEquals("in", tokens.get(1).value());
+
+        assertEquals(TokenType.Word, tokens.get(2).type());
+        assertEquals("10a", tokens.get(2).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(3).type());
+        assertEquals(".", tokens.get(3).value());
+    }
+
+    @Test
+    void tokenizeShouldHandleIsolatedPunctuations() {
+        var tokens = model.tokenize("This is a symbol: .");
+
+        assertEquals(6, tokens.size());
+
+        assertEquals(TokenType.Word, tokens.get(0).type());
+        assertEquals("This", tokens.get(0).value());
+
+        assertEquals(TokenType.Word, tokens.get(1).type());
+        assertEquals("is", tokens.get(1).value());
+
+        assertEquals(TokenType.Word, tokens.get(2).type());
+        assertEquals("a", tokens.get(2).value());
+
+        assertEquals(TokenType.Word, tokens.get(3).type());
+        assertEquals("symbol", tokens.get(3).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(4).type());
+        assertEquals(":", tokens.get(4).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(5).type());
+        assertEquals(".", tokens.get(5).value());
     }
 }

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/FrenchLanguageModelTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/FrenchLanguageModelTest.java
@@ -2,6 +2,8 @@ package com.munetmo.lingetic.LanguageService.Entities.LanguageModels;
 
 import com.munetmo.lingetic.LanguageService.Entities.LanguageModels.FrenchLanguageModel;
 import com.munetmo.lingetic.LanguageService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Token;
+import com.munetmo.lingetic.LanguageService.Entities.TokenType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -135,5 +137,202 @@ class FrenchLanguageModelTest {
         assertFalse(frenchLanguageModel.areEquivalent("du", "dû")); // "of the" vs "due"
         assertFalse(frenchLanguageModel.areEquivalent("sur", "sûr")); // "on" vs "sure"
         assertFalse(frenchLanguageModel.areEquivalent("la", "là")); // "the" vs "there"
+    }
+
+
+    @Test
+    void tokenizeShouldTokenizeSimpleSentences() {
+        var tokens = frenchLanguageModel.tokenize("Bonjour, monde!");
+
+        assertEquals(4, tokens.size());
+
+        assertEquals(TokenType.Word, tokens.get(0).type());
+        assertEquals("Bonjour", tokens.get(0).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(1).type());
+        assertEquals(",", tokens.get(1).value());
+
+        assertEquals(TokenType.Word, tokens.get(2).type());
+        assertEquals("monde", tokens.get(2).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(3).type());
+        assertEquals("!", tokens.get(3).value());
+    }
+
+    @Test
+    void tokenizeShouldKeepPunctuationBetweenLettersAsOneWord() {
+        var tokens = frenchLanguageModel.tokenize("J'irai quand vous l'aurez terminé, et je suis d'accord.");
+
+        assertEquals(11, tokens.size());
+
+        assertEquals(TokenType.Word, tokens.get(0).type());
+        assertEquals("J'irai", tokens.get(0).value());
+
+        assertEquals(TokenType.Word, tokens.get(1).type());
+        assertEquals("quand", tokens.get(1).value());
+
+        assertEquals(TokenType.Word, tokens.get(2).type());
+        assertEquals("vous", tokens.get(2).value());
+
+        assertEquals(TokenType.Word, tokens.get(3).type());
+        assertEquals("l'aurez", tokens.get(3).value());
+
+        assertEquals(TokenType.Word, tokens.get(4).type());
+        assertEquals("terminé", tokens.get(4).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(5).type());
+        assertEquals(",", tokens.get(5).value());
+
+        assertEquals(TokenType.Word, tokens.get(6).type());
+        assertEquals("et", tokens.get(6).value());
+
+        assertEquals(TokenType.Word, tokens.get(7).type());
+        assertEquals("je", tokens.get(7).value());
+
+        assertEquals(TokenType.Word, tokens.get(8).type());
+        assertEquals("suis", tokens.get(8).value());
+
+        assertEquals(TokenType.Word, tokens.get(9).type());
+        assertEquals("d'accord", tokens.get(9).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(10).type());
+        assertEquals(".", tokens.get(10).value());
+    }
+
+    @Test
+    void tokenizeShouldTokenizeNumbers() {
+        var tokens = frenchLanguageModel.tokenize("J'ai 10 ans.");
+        assertEquals(4, tokens.size());
+
+        assertEquals(TokenType.Word, tokens.get(0).type());
+        assertEquals("J'ai", tokens.get(0).value());
+
+        assertEquals(TokenType.Number, tokens.get(1).type());
+        assertEquals("10", tokens.get(1).value());
+
+        assertEquals(TokenType.Word, tokens.get(2).type());
+        assertEquals("ans", tokens.get(2).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(3).type());
+        assertEquals(".", tokens.get(3).value());
+    }
+
+    @Test
+    void tokenizeShouldTreatNumbersWithPunctuationAsNumbers() {
+        var tokens = frenchLanguageModel.tokenize("(123) 1+2 4,500 3.14 4#2");
+        assertEquals(5, tokens.size());
+
+        assertEquals(new Token(TokenType.Number, "(123)"), tokens.get(0));
+        assertEquals(new Token(TokenType.Number, "1+2"), tokens.get(1));
+        assertEquals(new Token(TokenType.Number, "4,500"), tokens.get(2));
+        assertEquals(new Token(TokenType.Number, "3.14"), tokens.get(3));
+        assertEquals(new Token(TokenType.Number, "4#2"), tokens.get(4));
+    }
+
+    @Test
+    void tokenizeShouldTreatAMixOfNumbersAndLettersAsWords() {
+        var tokens = frenchLanguageModel.tokenize("Je suis dans l'appartement 10A.");
+        assertEquals(6, tokens.size());
+
+        assertEquals(TokenType.Word, tokens.get(0).type());
+        assertEquals("Je", tokens.get(0).value());
+
+        assertEquals(TokenType.Word, tokens.get(1).type());
+        assertEquals("suis", tokens.get(1).value());
+
+        assertEquals(TokenType.Word, tokens.get(2).type());
+        assertEquals("dans", tokens.get(2).value());
+
+        assertEquals(TokenType.Word, tokens.get(3).type());
+        assertEquals("l'appartement", tokens.get(3).value());
+
+        assertEquals(TokenType.Word, tokens.get(4).type());
+        assertEquals("10A", tokens.get(4).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(5).type());
+        assertEquals(".", tokens.get(5).value());
+    }
+
+    @Test
+    void tokenizeShouldHandleFrenchGuillemets() {
+        var tokens = frenchLanguageModel.tokenize("« Bonjour le monde ! »");
+        
+        assertEquals(6, tokens.size());
+        
+        assertEquals(TokenType.Punctuation, tokens.get(0).type());
+        assertEquals("«", tokens.get(0).value());
+        
+        assertEquals(TokenType.Word, tokens.get(1).type());
+        assertEquals("Bonjour", tokens.get(1).value());
+        
+        assertEquals(TokenType.Word, tokens.get(2).type());
+        assertEquals("le", tokens.get(2).value());
+        
+        assertEquals(TokenType.Word, tokens.get(3).type());
+        assertEquals("monde", tokens.get(3).value());
+        
+        assertEquals(TokenType.Punctuation, tokens.get(4).type());
+        assertEquals("!", tokens.get(4).value());
+        
+        assertEquals(TokenType.Punctuation, tokens.get(5).type());
+        assertEquals("»", tokens.get(5).value());
+    }
+    
+    @Test
+    void tokenizeShouldHandleNestedQuotations() {
+        var tokens = frenchLanguageModel.tokenize("Elle a dit : « Il m'a répondu \"Je ne sais pas\" hier. »");
+        
+        assertEquals(17, tokens.size());
+        
+        assertEquals(TokenType.Word, tokens.get(0).type());
+        assertEquals("Elle", tokens.get(0).value());
+        
+        assertEquals(TokenType.Word, tokens.get(1).type());
+        assertEquals("a", tokens.get(1).value());
+        
+        assertEquals(TokenType.Word, tokens.get(2).type());
+        assertEquals("dit", tokens.get(2).value());
+        
+        assertEquals(TokenType.Punctuation, tokens.get(3).type());
+        assertEquals(":", tokens.get(3).value());
+        
+        assertEquals(TokenType.Punctuation, tokens.get(4).type());
+        assertEquals("«", tokens.get(4).value());
+        
+        assertEquals(TokenType.Word, tokens.get(5).type());
+        assertEquals("Il", tokens.get(5).value());
+        
+        assertEquals(TokenType.Word, tokens.get(6).type());
+        assertEquals("m'a", tokens.get(6).value());
+        
+        assertEquals(TokenType.Word, tokens.get(7).type());
+        assertEquals("répondu", tokens.get(7).value());
+        
+        assertEquals(TokenType.Punctuation, tokens.get(8).type());
+        assertEquals("\"", tokens.get(8).value());
+        
+        assertEquals(TokenType.Word, tokens.get(9).type());
+        assertEquals("Je", tokens.get(9).value());
+        
+        assertEquals(TokenType.Word, tokens.get(10).type());
+        assertEquals("ne", tokens.get(10).value());
+        
+        assertEquals(TokenType.Word, tokens.get(11).type());
+        assertEquals("sais", tokens.get(11).value());
+        
+        assertEquals(TokenType.Word, tokens.get(12).type());
+        assertEquals("pas", tokens.get(12).value());
+        
+        assertEquals(TokenType.Punctuation, tokens.get(13).type());
+        assertEquals("\"", tokens.get(13).value());
+
+        assertEquals(TokenType.Word, tokens.get(14).type());
+        assertEquals("hier", tokens.get(14).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(15).type());
+        assertEquals(".", tokens.get(15).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(16).type());
+        assertEquals("»", tokens.get(16).value());
     }
 }

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/FrenchLanguageModelTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/FrenchLanguageModelTest.java
@@ -335,4 +335,39 @@ class FrenchLanguageModelTest {
         assertEquals(TokenType.Punctuation, tokens.get(16).type());
         assertEquals("»", tokens.get(16).value());
     }
+
+    @Test
+    void shouldHandleConsecutivePunctuationEnding() {
+        var tokens = frenchLanguageModel.tokenize("Quoi?!");
+
+        assertEquals(3, tokens.size());
+
+        assertEquals(TokenType.Word, tokens.get(0).type());
+        assertEquals("Quoi", tokens.get(0).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(1).type());
+        assertEquals("?", tokens.get(1).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(2).type());
+        assertEquals("!", tokens.get(2).value());
+    }
+
+    @Test
+    void shouldHandleConsecutivePunctuationBeginning() {
+        var tokens = frenchLanguageModel.tokenize("--Maintenant!");
+
+        assertEquals(4, tokens.size());
+
+        assertEquals(TokenType.Punctuation, tokens.get(0).type());
+        assertEquals("-", tokens.get(0).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(1).type());
+        assertEquals("-", tokens.get(1).value());
+
+        assertEquals(TokenType.Word, tokens.get(2).type());
+        assertEquals("Maintenant", tokens.get(2).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(3).type());
+        assertEquals("!", tokens.get(3).value());
+    }
 }

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/TurkishLanguageModelTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/TurkishLanguageModelTest.java
@@ -219,4 +219,39 @@ class TurkishLanguageModelTest {
         assertEquals(TokenType.Punctuation, tokens.get(5).type());
         assertEquals(".", tokens.get(5).value());
     }
+
+    @Test
+    void shouldHandleConsecutivePunctuationEnding() {
+        var tokens = model.tokenize("Ne?!");
+
+        assertEquals(3, tokens.size());
+
+        assertEquals(TokenType.Word, tokens.get(0).type());
+        assertEquals("Ne", tokens.get(0).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(1).type());
+        assertEquals("?", tokens.get(1).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(2).type());
+        assertEquals("!", tokens.get(2).value());
+    }
+
+    @Test
+    void shouldHandleConsecutivePunctuationBeginning() {
+        var tokens = model.tokenize("--Şimdi!");
+
+        assertEquals(4, tokens.size());
+
+        assertEquals(TokenType.Punctuation, tokens.get(0).type());
+        assertEquals("-", tokens.get(0).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(1).type());
+        assertEquals("-", tokens.get(1).value());
+
+        assertEquals(TokenType.Word, tokens.get(2).type());
+        assertEquals("Şimdi", tokens.get(2).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(3).type());
+        assertEquals("!", tokens.get(3).value());
+    }
 }

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/TurkishLanguageModelTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/TurkishLanguageModelTest.java
@@ -2,6 +2,8 @@ package com.munetmo.lingetic.LanguageService.Entities.LanguageModels;
 
 import com.munetmo.lingetic.LanguageService.Entities.LanguageModels.TurkishLanguageModel;
 import com.munetmo.lingetic.LanguageService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Token;
+import com.munetmo.lingetic.LanguageService.Entities.TokenType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -80,5 +82,141 @@ class TurkishLanguageModelTest {
     void areEquivalentShouldHandleApostrophes() {
         assertFalse(model.areEquivalent("İstanbul'da", "istanbulda"));
         assertFalse(model.areEquivalent("Ali'nin", "alinin"));
+    }
+
+    @Test
+    void tokenizeShouldTokenizeSimpleSentences() {
+        var tokens = model.tokenize("Merhaba, dünya!");
+
+        assertEquals(4, tokens.size());
+
+        assertEquals(TokenType.Word, tokens.get(0).type());
+        assertEquals("Merhaba", tokens.get(0).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(1).type());
+        assertEquals(",", tokens.get(1).value());
+
+        assertEquals(TokenType.Word, tokens.get(2).type());
+        assertEquals("dünya", tokens.get(2).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(3).type());
+        assertEquals("!", tokens.get(3).value());
+    }
+
+    @Test
+    void tokenizeShouldKeepPunctuationBetweenLettersAsOneWord() {
+        var tokens = model.tokenize("Ben'im kitabım ve Ali'nin kalemi.");
+
+        assertEquals(6, tokens.size());
+
+        assertEquals(TokenType.Word, tokens.get(0).type());
+        assertEquals("Ben'im", tokens.get(0).value());
+
+        assertEquals(TokenType.Word, tokens.get(1).type());
+        assertEquals("kitabım", tokens.get(1).value());
+
+        assertEquals(TokenType.Word, tokens.get(2).type());
+        assertEquals("ve", tokens.get(2).value());
+
+        assertEquals(TokenType.Word, tokens.get(3).type());
+        assertEquals("Ali'nin", tokens.get(3).value());
+
+        assertEquals(TokenType.Word, tokens.get(4).type());
+        assertEquals("kalemi", tokens.get(4).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(5).type());
+        assertEquals(".", tokens.get(5).value());
+    }
+
+    @Test
+    void tokenizeShouldTokenizeNumbers() {
+        var tokens = model.tokenize("Ben 10 yaşındayım.");
+        assertEquals(4, tokens.size());
+
+        assertEquals(TokenType.Word, tokens.get(0).type());
+        assertEquals("Ben", tokens.get(0).value());
+
+        assertEquals(TokenType.Number, tokens.get(1).type());
+        assertEquals("10", tokens.get(1).value());
+
+        assertEquals(TokenType.Word, tokens.get(2).type());
+        assertEquals("yaşındayım", tokens.get(2).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(3).type());
+        assertEquals(".", tokens.get(3).value());
+    }
+
+    @Test
+    void tokenizeShouldTreatNumbersWithPunctuationAsNumbers() {
+        var tokens = model.tokenize("(123) 1+2 4.500 3,14 4#2");
+        assertEquals(5, tokens.size());
+
+        assertEquals(new Token(TokenType.Number, "(123)"), tokens.get(0));
+        assertEquals(new Token(TokenType.Number, "1+2"), tokens.get(1));
+        assertEquals(new Token(TokenType.Number, "4.500"), tokens.get(2));
+        assertEquals(new Token(TokenType.Number, "3,14"), tokens.get(3));
+        assertEquals(new Token(TokenType.Number, "4#2"), tokens.get(4));
+    }
+
+    @Test
+    void tokenizeShouldTreatAMixOfNumbersAndLettersAsWords() {
+        var tokens = model.tokenize("Oda 10A'da.");
+        assertEquals(3, tokens.size());
+
+        assertEquals(TokenType.Word, tokens.get(0).type());
+        assertEquals("Oda", tokens.get(0).value());
+
+        assertEquals(TokenType.Word, tokens.get(1).type());
+        assertEquals("10A'da", tokens.get(1).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(2).type());
+        assertEquals(".", tokens.get(2).value());
+    }
+
+    @Test
+    void tokenizeShouldHandleIsolatedPunctuations() {
+        var tokens = model.tokenize("Bu bir sembol: .");
+
+        assertEquals(5, tokens.size());
+
+        assertEquals(TokenType.Word, tokens.get(0).type());
+        assertEquals("Bu", tokens.get(0).value());
+
+        assertEquals(TokenType.Word, tokens.get(1).type());
+        assertEquals("bir", tokens.get(1).value());
+
+        assertEquals(TokenType.Word, tokens.get(2).type());
+        assertEquals("sembol", tokens.get(2).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(3).type());
+        assertEquals(":", tokens.get(3).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(4).type());
+        assertEquals(".", tokens.get(4).value());
+    }
+
+    @Test
+    void tokenizeShouldHandleTurkishQuotations() {
+        var tokens = model.tokenize("O \"Merhaba\" dedi.");
+        
+        assertEquals(6, tokens.size());
+        
+        assertEquals(TokenType.Word, tokens.get(0).type());
+        assertEquals("O", tokens.get(0).value());
+        
+        assertEquals(TokenType.Punctuation, tokens.get(1).type());
+        assertEquals("\"", tokens.get(1).value());
+        
+        assertEquals(TokenType.Word, tokens.get(2).type());
+        assertEquals("Merhaba", tokens.get(2).value());
+        
+        assertEquals(TokenType.Punctuation, tokens.get(3).type());
+        assertEquals("\"", tokens.get(3).value());
+        
+        assertEquals(TokenType.Word, tokens.get(4).type());
+        assertEquals("dedi", tokens.get(4).value());
+        
+        assertEquals(TokenType.Punctuation, tokens.get(5).type());
+        assertEquals(".", tokens.get(5).value());
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced tokenization support for English, French, and Turkish language models, allowing input text to be split into words, numbers, and punctuation tokens.
  - Added a new helper class to centralize normalization and tokenization logic for Latin-script languages, improving consistency across language models.
- **Tests**
  - Added comprehensive unit tests for English, French, and Turkish tokenization, verifying correct token classification and handling of various text scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->