### PR TITLE
Include explanation with attempt response

### DIFF
--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptResponses/FillInTheBlanksAttemptResponse.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptResponses/FillInTheBlanksAttemptResponse.java
@@ -2,19 +2,30 @@ package com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses;
 
 import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
+import com.munetmo.lingetic.LanguageTestService.Entities.Questions.FillInTheBlanksQuestion.WordExplanation;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.Objects;
 
 public final class FillInTheBlanksAttemptResponse implements AttemptResponse {
     private static final QuestionType questionType = QuestionType.FillInTheBlanks;
     private final AttemptStatus attemptStatus;
     private final String correctAnswer;
+    private final List<WordExplanation> explanation;
 
     public FillInTheBlanksAttemptResponse(AttemptStatus attemptStatus, String correctAnswer) {
+        this(attemptStatus, correctAnswer, null);
+    }
+
+    public FillInTheBlanksAttemptResponse(AttemptStatus attemptStatus, String correctAnswer, @Nullable List<WordExplanation> explanation) {
         if (correctAnswer.isBlank()) {
             throw new IllegalArgumentException("correctAnswer cannot be blank.");
         }
 
         this.attemptStatus = attemptStatus;
         this.correctAnswer = correctAnswer;
+        this.explanation = Objects.requireNonNullElse(explanation, List.of());
     }
 
     @Override
@@ -29,5 +40,9 @@ public final class FillInTheBlanksAttemptResponse implements AttemptResponse {
 
     public String getCorrectAnswer() {
         return correctAnswer;
+    }
+
+    public List<WordExplanation> getExplanation() {
+        return explanation;
     }
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestion.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestion.java
@@ -114,7 +114,8 @@ public final class FillInTheBlanksQuestion implements Question {
 
         return new FillInTheBlanksAttemptResponse(
             areEquivalent ? AttemptStatus.Success : AttemptStatus.Failure,
-            answer
+            answer,
+            this.explanation
         );
     }
 

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptResponses/FillInTheBlanksAttemptResponseTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptResponses/FillInTheBlanksAttemptResponseTest.java
@@ -2,7 +2,10 @@ package com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses;
 
 import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
+import com.munetmo.lingetic.LanguageTestService.Entities.Questions.FillInTheBlanksQuestion.WordExplanation;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -14,6 +17,7 @@ class FillInTheBlanksAttemptResponseTest {
         assertEquals(AttemptStatus.Success, response.getAttemptStatus());
         assertEquals("test answer", response.getCorrectAnswer());
         assertEquals(QuestionType.FillInTheBlanks, response.getQuestionType());
+        assertEquals(List.of(), response.getExplanation());
     }
 
     @Test
@@ -24,5 +28,30 @@ class FillInTheBlanksAttemptResponseTest {
         );
         assertNotNull(exception.getMessage());
         assertTrue(exception.getMessage().contains("correctAnswer"));
+    }
+
+    @Test
+    void constructorShouldCreateValidObjectWithExplanation() {
+        var explanation = java.util.List.of(
+            new WordExplanation(1, "word1", List.of("p1"), "c1"),
+            new WordExplanation(2, "word2", List.of("p2"), "c2")
+        );
+        var response = new FillInTheBlanksAttemptResponse(AttemptStatus.Success, "test answer", explanation);
+
+        assertEquals(AttemptStatus.Success, response.getAttemptStatus());
+        assertEquals("test answer", response.getCorrectAnswer());
+        assertEquals(QuestionType.FillInTheBlanks, response.getQuestionType());
+        assertEquals(explanation, response.getExplanation());
+    }
+
+    @Test
+    void constructorShouldCreateValidObjectWithNullExplanation() {
+        var response = new FillInTheBlanksAttemptResponse(AttemptStatus.Success, "test answer", null);
+
+        assertEquals(AttemptStatus.Success, response.getAttemptStatus());
+        assertEquals("test answer", response.getCorrectAnswer());
+        assertEquals(QuestionType.FillInTheBlanks, response.getQuestionType());
+        assertNotNull(response.getExplanation());
+        assertTrue(response.getExplanation().isEmpty());
     }
 }

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestionTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/FillInTheBlanksQuestionTest.java
@@ -101,8 +101,11 @@ class FillInTheBlanksQuestionTest {
 
     @Test
     void assessAttemptShouldReturnSuccessForCorrectAnswer() {
-        var question = new FillInTheBlanksQuestion(
-            "id", Language.English, "Fill in the ___", "hint", "correct", 5, defaultQuestionListId
+        var explanation = List.of(
+            new FillInTheBlanksQuestion.WordExplanation(1, "blank", List.of("article", "plural", "definite"), "test comment")
+        );
+        FillInTheBlanksQuestion question = new FillInTheBlanksQuestion(
+            "id", Language.English, "Fill in the ___", "hint", "blank", 5, defaultQuestionListId, explanation
         );
         var request = new FillInTheBlanksAttemptRequest(question.getID(), question.answer);
 
@@ -110,12 +113,16 @@ class FillInTheBlanksQuestionTest {
 
         assertEquals(AttemptStatus.Success, response.getAttemptStatus());
         assertEquals(question.answer, response.getCorrectAnswer());
+        assertEquals(explanation, response.getExplanation());
     }
 
     @Test
     void assessAttemptShouldReturnFailureForIncorrectAnswer() {
-        var question = new FillInTheBlanksQuestion(
-            "id", Language.English, "Fill in the ___", "hint", "correct", 5, defaultQuestionListId
+        var explanation = List.of(
+            new FillInTheBlanksQuestion.WordExplanation(1, "blank", List.of("article", "plural", "definite"), "test comment")
+        );
+        FillInTheBlanksQuestion question = new FillInTheBlanksQuestion(
+            "id", Language.English, "Fill in the ___", "hint", "blank", 5, defaultQuestionListId, explanation
         );
         var request = new FillInTheBlanksAttemptRequest(question.getID(), "wrong");
 
@@ -123,6 +130,7 @@ class FillInTheBlanksQuestionTest {
 
         assertEquals(AttemptStatus.Failure, response.getAttemptStatus());
         assertEquals(question.answer, response.getCorrectAnswer());
+        assertEquals(explanation, response.getExplanation());
     }
 
     @Test


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Added word explanations to the fill-in-the-blanks attempt response so users receive detailed feedback with their answer.

- **New Features**
  - The attempt response now includes a list of word explanations.
  - Tests updated to check for explanation data in responses.

<!-- End of auto-generated description by mrge. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detailed explanations to fill-in-the-blanks attempt responses, allowing users to view word explanations after submitting an answer.

- **Bug Fixes**
  - Ensured explanation lists in responses are never null, improving reliability.

- **Tests**
  - Expanded test coverage to verify explanation handling and null safety in fill-in-the-blanks responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->