### PR TITLE
Disable Turkish from the frontend

### DIFF
--- a/lingetic-nextjs-frontend/app/languages/constants.ts
+++ b/lingetic-nextjs-frontend/app/languages/constants.ts
@@ -22,7 +22,7 @@ export const languages: LanguageProperty[] = [
     id: "Turkish",
     name: "Turkish",
     image: "/img/languages/turkish-flag.png",
-    isSupported: true,
+    isSupported: false,
   },
   {
     id: "Spanish",


### PR DESCRIPTION
Turkish is not a business focus for now due to
projected low demand.
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Turkish is now disabled on the frontend and will not appear as a supported language.

<!-- End of auto-generated description by mrge. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the status of Turkish to indicate it is no longer a supported language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->