### PR TITLE
Reset attempt response with new questions

### DIFF
--- a/lingetic-nextjs-frontend/app/components/questions/FillInTheBlanks/FillInTheBlanks.tsx
+++ b/lingetic-nextjs-frontend/app/components/questions/FillInTheBlanks/FillInTheBlanks.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import assert from "@/utilities/assert";
 import type QuestionProps from "../QuestionProps";
@@ -28,6 +28,10 @@ export default function FillInTheBlanks({
   const [attemptResponse, setAttemptResponse] = useState<
     FillInTheBlanksAttemptResponse | undefined
   >(undefined);
+
+  useEffect(() => {
+    setAttemptResponse(undefined);
+  }, [question.id]);
 
   const { answer, setAnswer, checkAnswer, isChecking, isChecked, isError } =
     useUserAnswer(question.id);


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
The attempt response now resets when a new fill-in-the-blanks question is loaded, so users always start fresh with each question.

<!-- End of auto-generated description by mrge. -->

