### PR TITLE
Show full sentence if there are no explanations

### DIFF
--- a/lingetic-nextjs-frontend/app/components/questions/FillInTheBlanks/Result.tsx
+++ b/lingetic-nextjs-frontend/app/components/questions/FillInTheBlanks/Result.tsx
@@ -1,7 +1,6 @@
 import type { FillInTheBlanksAttemptResponse } from "@/utilities/api-types";
 import WordExplanationHover from "./WordExplanationHover";
 import type { FillInTheBlanksQuestion } from "@/utilities/api-types";
-import assert from "@/utilities/assert";
 
 interface ResultBoxProps {
   question: FillInTheBlanksQuestion;
@@ -12,10 +11,13 @@ export default function ResultBox({
   question,
   attemptResponse,
 }: ResultBoxProps) {
-  assert(
-    attemptResponse.explanation.length > 0,
-    `explanation not available for question ${question.id}`
-  );
+  if (attemptResponse.explanation.length === 0) {
+    const fullSentence = question.text.replace(
+      /_+/,
+      attemptResponse.correctAnswer
+    );
+    return <div>{fullSentence}</div>;
+  }
 
   return (
     <div className="flex flex-wrap gap-1">


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Now shows the full sentence with the correct answer if there are no explanations for a fill-in-the-blanks question.

<!-- End of auto-generated description by mrge. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of missing explanations in fill-in-the-blank question results by displaying the full sentence with the correct answer when no explanation is available, instead of showing an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->