### PR TITLE
Add JapaneseModifiedHepburn language to the backend

### DIFF
--- a/lingetic-nextjs-frontend/app/languages/constants.ts
+++ b/lingetic-nextjs-frontend/app/languages/constants.ts
@@ -49,8 +49,14 @@ export const languages: LanguageProperty[] = [
     isSupported: false,
   },
   {
+    id: "JapaneseModifiedHepburn",
+    name: "Japanese 1",
+    image: "/img/languages/japanese-flag.png",
+    isSupported: true,
+  },
+  {
     id: "Japanese",
-    name: "Japanese",
+    name: "Japanese 2",
     image: "/img/languages/japanese-flag.png",
     isSupported: true,
   },
@@ -95,6 +101,7 @@ export const languageNameToCode: Record<string, string> = {
   Italian: "it",
   Portuguese: "pt",
   Japanese: "ja",
+  JapaneseModifiedHepburn: "ja-hepburn",
   Korean: "ko",
   Chinese: "zh",
   Russian: "ru",

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/Language.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/Language.java
@@ -7,4 +7,5 @@ public enum Language {
     Turkish,
     Swedish,
     Japanese,
+    JapaneseModifiedHepburn,
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/JapaneseModifiedHepburnLanguageModel.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/JapaneseModifiedHepburnLanguageModel.java
@@ -1,0 +1,26 @@
+package com.munetmo.lingetic.LanguageService.Entities.LanguageModels;
+
+import com.munetmo.lingetic.LanguageService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Token;
+
+import java.util.List;
+import java.util.Locale;
+
+public final class JapaneseModifiedHepburnLanguageModel implements LanguageModel {
+    private static final LatinScriptLanguageModelHelper helper = new LatinScriptLanguageModelHelper(Locale.JAPAN);
+
+    @Override
+    public Language getLanguage() {
+        return Language.JapaneseModifiedHepburn;
+    }
+
+    @Override
+    public boolean areEquivalent(String s1, String s2) {
+        return helper.areEquivalent(s1, s2);
+    }
+
+    @Override
+    public List<Token> tokenize(String input) {
+        return helper.tokenize(input);
+    }
+}

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/LanguageModel.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/LanguageModel.java
@@ -6,7 +6,8 @@ import com.munetmo.lingetic.LanguageService.Entities.Token;
 import java.util.List;
 import java.util.Map;
 
-public sealed interface LanguageModel permits EnglishLanguageModel, FrenchLanguageModel, TurkishLanguageModel, SwedishLanguageModel, JapaneseLanguageModel {
+public sealed interface LanguageModel permits EnglishLanguageModel, FrenchLanguageModel, TurkishLanguageModel,
+        SwedishLanguageModel, JapaneseLanguageModel, JapaneseModifiedHepburnLanguageModel {
     Language getLanguage();
 
     boolean areEquivalent(String s1, String s2);
@@ -18,7 +19,8 @@ public sealed interface LanguageModel permits EnglishLanguageModel, FrenchLangua
             Language.French, new FrenchLanguageModel(),
             Language.Turkish, new TurkishLanguageModel(),
             Language.Swedish, new SwedishLanguageModel(),
-            Language.Japanese, new JapaneseLanguageModel()
+            Language.Japanese, new JapaneseLanguageModel(),
+            Language.JapaneseModifiedHepburn, new JapaneseModifiedHepburnLanguageModel()
     );
 
     static LanguageModel getLanguageModel(Language language) {

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/LatinScriptLanguageModelHelper.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/LatinScriptLanguageModelHelper.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
 
 public final class LatinScriptLanguageModelHelper {
     private static final String TERMINAL_PUNCTUATION = ".?!;,:-";
-    private static final String SPECIFIC_CHARACTERS = "àâäæçéèêëîïôœùûüÿçğıöşüåäö";
+    private static final String SPECIFIC_CHARACTERS = "àâäæçéèêëîïôœùûüÿçğıöşüåäöāīūēō";
     private static final String SURROUNDING_PUNCTUATION = "'\"«»";
 
     private static final Pattern LEADING_PUNCTUATION_PATTERN = Pattern.compile(

--- a/lingetic-spring-backend/src/main/resources/META-INF/native-image/com.munetmo/lingetic/reachability-metadata.json
+++ b/lingetic-spring-backend/src/main/resources/META-INF/native-image/com.munetmo/lingetic/reachability-metadata.json
@@ -8411,6 +8411,9 @@
       "glob": "db/migration/V6__Add_Japanese_Language.sql"
     },
     {
+      "glob": "db/migration/V7__Add_Japanese_Modified_Hepburn_Language.sql"
+    },
+    {
       "glob": "dictionaries/system_full.dic"
     },
     {

--- a/lingetic-spring-backend/src/main/resources/db/migration/V7__Add_Japanese_Modified_Hepburn_Language.sql
+++ b/lingetic-spring-backend/src/main/resources/db/migration/V7__Add_Japanese_Modified_Hepburn_Language.sql
@@ -1,0 +1,2 @@
+-- Add JapaneseModifiedHepburn to supported languages
+INSERT INTO languages (name) VALUES ('JapaneseModifiedHepburn');

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/JapaneseModifiedHepburnLanguageModelTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/JapaneseModifiedHepburnLanguageModelTest.java
@@ -1,0 +1,255 @@
+package com.munetmo.lingetic.LanguageService.Entities.LanguageModels;
+
+import com.munetmo.lingetic.LanguageService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.TokenType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JapaneseModifiedHepburnLanguageModelTest {
+    private JapaneseModifiedHepburnLanguageModel model;
+
+    @BeforeEach
+    void setUp() {
+        model = new JapaneseModifiedHepburnLanguageModel();
+    }
+
+    @Test
+    void getLanguageShouldReturnJapaneseModifiedHepburn() {
+        assertEquals(Language.JapaneseModifiedHepburn, model.getLanguage());
+    }
+
+    @Test
+    void tokenizeShouldHandleEmptyStrings() {
+        assertTrue(model.tokenize("").isEmpty());
+        assertTrue(model.tokenize(" ").isEmpty());
+    }
+
+    @Test
+    void areEquivalentShouldHandleEmptyStrings() {
+        assertTrue(model.areEquivalent("", ""));
+        assertTrue(model.areEquivalent(" ", " "));
+        assertTrue(model.areEquivalent(" ", ""));
+    }
+
+    @Test
+    void areEquivalentShouldMatchRomanizedForms() {
+        assertTrue(model.areEquivalent("inu", "inu"));
+    }
+
+    @Test
+    void areEquivalentShouldIgnorePunctuation() {
+        assertTrue(model.areEquivalent("inu!", "inu"));
+    }
+
+    @Test
+    void areEquivalentShouldWorkWithMacronA() {
+        assertTrue(model.areEquivalent("kādo", "kādo")); // card
+        assertFalse(model.areEquivalent("kādo", "kaado"));
+        assertTrue(model.areEquivalent("KĀDO", "kādo")); // case insensitive
+        assertFalse(model.areEquivalent("kado", "kādo")); // different meaning
+    }
+
+    @Test
+    void areEquivalentShouldWorkWithMacronI() {
+        assertTrue(model.areEquivalent("onīsan", "onīsan")); // older brother
+        assertFalse(model.areEquivalent("onīsan", "oniisan"));
+        assertTrue(model.areEquivalent("ONĪSAN", "onīsan")); // case insensitive
+        assertFalse(model.areEquivalent("onisan", "onīsan")); // different meaning
+    }
+
+    @Test
+    void areEquivalentShouldWorkWithMacronU() {
+        assertTrue(model.areEquivalent("yūki", "yūki")); // courage
+        assertFalse(model.areEquivalent("yūki", "yuuki"));
+        assertTrue(model.areEquivalent("YŪKI", "yūki")); // case insensitive
+        assertFalse(model.areEquivalent("yuki", "yūki")); // different meaning (snow vs courage)
+    }
+
+    @Test
+    void areEquivalentShouldWorkWithMacronE() {
+        assertTrue(model.areEquivalent("onēsan", "onēsan")); // older sister
+        assertFalse(model.areEquivalent("onēsan", "oneesan"));
+        assertTrue(model.areEquivalent("ONĒSAN", "onēsan")); // case insensitive
+        assertFalse(model.areEquivalent("onesan", "onēsan")); // different meaning
+    }
+
+    @Test
+    void areEquivalentShouldWorkWithMacronO() {
+        assertTrue(model.areEquivalent("tōkyō", "tōkyō")); // Tokyo
+        assertFalse(model.areEquivalent("tōkyō", "toukyou"));
+        assertTrue(model.areEquivalent("TŌKYŌ", "tōkyō")); // case insensitive
+        assertFalse(model.areEquivalent("tokyo", "tōkyō")); // incorrect romanization
+    }
+
+    @Test
+    void areEquivalentShouldWorkWithMultipleMacrons() {
+        assertTrue(model.areEquivalent("tōkyō", "tōkyō")); // Tokyo
+        assertTrue(model.areEquivalent("kyōsō", "kyōsō")); // competition
+        assertTrue(model.areEquivalent("shōchū", "shōchū")); // distilled spirits
+        assertTrue(model.areEquivalent("kōkōsei", "kōkōsei")); // high school student
+    }
+
+    @Test
+    void areEquivalentShouldHandleMacronsWithPunctuation() {
+        assertTrue(model.areEquivalent("Tōkyō!", "tōkyō"));
+        assertTrue(model.areEquivalent("Tōkyō?", "tōkyō"));
+        assertTrue(model.areEquivalent("Tōkyō...", "tōkyō"));
+    }
+
+    @Test
+    void areEquivalentShouldHandleMacronsWithSpaces() {
+        assertTrue(model.areEquivalent("  tōkyō  ", "tōkyō"));
+        assertFalse(model.areEquivalent("Tōkyō-to", "tōkyō to")); // Tokyo metropolis
+        assertTrue(model.areEquivalent("Tōkyō\tto", "tōkyō to"));
+    }
+
+    @Test
+    void tokenizeShouldHandleTokenTypes() {
+        var tokens = model.tokenize("Watashi wa 25-sai desu.");
+
+        assertEquals(5, tokens.size());
+
+        assertEquals(TokenType.Word, tokens.get(0).type());
+        assertEquals("Watashi", tokens.get(0).value());
+
+        assertEquals(TokenType.Word, tokens.get(1).type());
+        assertEquals("wa", tokens.get(1).value());
+
+        assertEquals(TokenType.Word, tokens.get(2).type());
+        assertEquals("25-sai", tokens.get(2).value());
+
+        assertEquals(TokenType.Word, tokens.get(3).type());
+        assertEquals("desu", tokens.get(3).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(4).type());
+        assertEquals(".", tokens.get(4).value());
+    }
+
+    @Test
+    void tokenizeShouldHandleMacronsInWords() {
+        var tokens = model.tokenize("Tōkyō wa ōkii desu.");
+
+        assertEquals(5, tokens.size());
+
+        assertEquals(TokenType.Word, tokens.get(0).type());
+        assertEquals("Tōkyō", tokens.get(0).value());
+
+        assertEquals(TokenType.Word, tokens.get(1).type());
+        assertEquals("wa", tokens.get(1).value());
+
+        assertEquals(TokenType.Word, tokens.get(2).type());
+        assertEquals("ōkii", tokens.get(2).value());
+
+        assertEquals(TokenType.Word, tokens.get(3).type());
+        assertEquals("desu", tokens.get(3).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(4).type());
+        assertEquals(".", tokens.get(4).value());
+    }
+
+    @Test
+    void tokenizeShouldHandleJapaneseQuotations() {
+        var tokens = model.tokenize("Sensei wa \"Konnichiwa\" to iimashita.");
+
+        assertEquals(8, tokens.size());
+
+        assertEquals(TokenType.Word, tokens.get(0).type());
+        assertEquals("Sensei", tokens.get(0).value());
+
+        assertEquals(TokenType.Word, tokens.get(1).type());
+        assertEquals("wa", tokens.get(1).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(2).type());
+        assertEquals("\"", tokens.get(2).value());
+
+        assertEquals(TokenType.Word, tokens.get(3).type());
+        assertEquals("Konnichiwa", tokens.get(3).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(4).type());
+        assertEquals("\"", tokens.get(4).value());
+
+        assertEquals(TokenType.Word, tokens.get(5).type());
+        assertEquals("to", tokens.get(5).value());
+
+        assertEquals(TokenType.Word, tokens.get(6).type());
+        assertEquals("iimashita", tokens.get(6).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(7).type());
+        assertEquals(".", tokens.get(7).value());
+    }
+
+    @Test
+    void tokenizeShouldHandleNumbers() {
+        var tokens = model.tokenize("Kurasu ni 42-nin imasu.");
+        assertEquals(5, tokens.size());
+
+        assertEquals(TokenType.Word, tokens.get(0).type());
+        assertEquals("Kurasu", tokens.get(0).value());
+
+        assertEquals(TokenType.Word, tokens.get(1).type());
+        assertEquals("ni", tokens.get(1).value());
+
+        assertEquals(TokenType.Word, tokens.get(2).type());
+        assertEquals("42-nin", tokens.get(2).value());
+
+        assertEquals(TokenType.Word, tokens.get(3).type());
+        assertEquals("imasu", tokens.get(3).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(4).type());
+        assertEquals(".", tokens.get(4).value());
+    }
+
+    @Test
+    void tokenizeShouldHandleComplexPunctuation() {
+        var tokens = model.tokenize("Sugoi...! Hontō?!");
+
+        assertEquals(8, tokens.size());
+
+        assertEquals(TokenType.Word, tokens.get(0).type());
+        assertEquals("Sugoi", tokens.get(0).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(1).type());
+        assertEquals(".", tokens.get(1).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(2).type());
+        assertEquals(".", tokens.get(2).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(3).type());
+        assertEquals(".", tokens.get(3).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(4).type());
+        assertEquals("!", tokens.get(4).value());
+
+        assertEquals(TokenType.Word, tokens.get(5).type());
+        assertEquals("Hontō", tokens.get(5).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(6).type());
+        assertEquals("?", tokens.get(6).value());
+
+        assertEquals(TokenType.Punctuation, tokens.get(7).type());
+        assertEquals("!", tokens.get(7).value());
+    }
+
+    @Test
+    void tokenizeShouldKeepNumbersAndLettersSeparate() {
+        var tokens = model.tokenize("Room 101A wa doko desu ka?");
+
+        assertEquals(7, tokens.size());
+        assertEquals(TokenType.Word, tokens.get(0).type());
+        assertEquals("Room", tokens.get(0).value());
+        assertEquals(TokenType.Word, tokens.get(1).type());
+        assertEquals("101A", tokens.get(1).value());
+        assertEquals(TokenType.Word, tokens.get(2).type());
+        assertEquals("wa", tokens.get(2).value());
+        assertEquals(TokenType.Word, tokens.get(3).type());
+        assertEquals("doko", tokens.get(3).value());
+        assertEquals(TokenType.Word, tokens.get(4).type());
+        assertEquals("desu", tokens.get(4).value());
+        assertEquals(TokenType.Word, tokens.get(5).type());
+        assertEquals("ka", tokens.get(5).value());
+        assertEquals(TokenType.Punctuation, tokens.get(6).type());
+        assertEquals("?", tokens.get(6).value());
+    }
+}

--- a/scripts/scripts/course.py
+++ b/scripts/scripts/course.py
@@ -132,6 +132,34 @@ Output:
 ]
 }
 """,
+    "JapaneseModifiedHepburn": """
+Example:
+
+Theme: Basic verbs, Level: Intermediate, Number: 2
+
+Output:
+
+{
+"data": [
+    {
+        "text": "Watashi wa shitte imasu!",
+        "translations": [
+            {
+                "text": "I know!"
+            }
+        ]
+    },
+    {
+        "text": "Tomu ga katteimasu.",
+        "translations": [
+            {
+                "text": "Tom is winning."
+            }
+        ]
+    }
+]
+}
+""",
 }
 
 

--- a/scripts/scripts/questions.py
+++ b/scripts/scripts/questions.py
@@ -79,6 +79,28 @@ Output:
 Reason: Both words `駅` (station) and `へ` (direction particle) are relevant to the theme and instructions, as they deal with locations and particles used for indicating direction.
         """,
     },
+    "JapaneseModifiedHepburn": {
+        "sentence": "gakusei wa toshokan de benkyou shimasu",
+        "word1": "de",
+        "word2": ["gakusei", "toshokan"],
+        "blank1": "gakusei wa toshokan ____ benkyou shimasu",
+        "blank2": [
+            "_____ wa toshokan de benkyou shimasu",
+            "gakusei wa _____ de benkyou shimasu",
+        ],
+        "example": """
+Example:
+Words: [{{"type":"Word","value":"watashi","sequenceNumber":1}},{{"type":"Word","value":"wa","sequenceNumber":2}},{{"type":"Word","value":"eki","sequenceNumber":3}},{{"type":"Word","value":"e","sequenceNumber":4}},{{"type":"Word","value":"ikimasu","sequenceNumber":5}}]
+
+Theme: Basic Locations and Transportation
+Instructions: Teach basic location particles (e, ni, de) and verbs of motion (iku, kuru). Focus on simple sentence structures using basic particles. Average sentence length: 3-5 words.
+
+Output:
+{{ "selectedWordsSequenceNumbers": [3, 4] }}
+
+Reason: Both words `eki` (station) and `e` (direction particle) are relevant to the theme and instructions, as they deal with locations and particles used for indicating direction.
+        """,
+    },
 }
 
 PROMPT_TEMPLATE = """Your job is to create fill-in-the-blank questions. To create a fill-in-the-blank question, start with a set of words: "{sentence}" Then choose a word to hide, say, "{word1}". The fill-in-the-blank question becomes: "{blank1}"

--- a/scripts/scripts/tts.py
+++ b/scripts/scripts/tts.py
@@ -16,6 +16,7 @@ LANGUAGE_TO_CODE = {
     "Turkish": "tr",
     "Swedish": "sv",
     "Japanese": "ja",
+    "JapaneseModifiedHepburn": "ja",
 }
 
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Added support for the JapaneseModifiedHepburn language to the backend, including language model, database migration, and tests.

- **New Features**
  - Implemented JapaneseModifiedHepburnLanguageModel with macron support.
  - Added database entry and unit tests for the new language.

<!-- End of auto-generated description by mrge. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the Japanese Modified Hepburn romanization system as a selectable language.
  - Included new example prompts and question templates using Japanese Modified Hepburn romanization.
- **Bug Fixes**
  - Improved recognition of specific accented Latin characters, including ā, ī, ū, ē, ō.
- **Tests**
  - Introduced comprehensive tests to verify correct handling and equivalence of Japanese Modified Hepburn romanized words.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->