### PR TITLE
Add method to combine tokens into strings

### DIFF
--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/EnglishLanguageModel.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/EnglishLanguageModel.java
@@ -30,4 +30,9 @@ public final class EnglishLanguageModel implements LanguageModel {
     public List<Token> tokenize(String input) {
         return helper.tokenize(input);
     }
+
+    @Override
+    public String combineTokens(List<Token> tokens) {
+        return helper.combineTokens(tokens);
+    }
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/FrenchLanguageModel.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/FrenchLanguageModel.java
@@ -27,4 +27,9 @@ public final class FrenchLanguageModel implements LanguageModel {
     public List<Token> tokenize(String input) {
         return helper.tokenize(input);
     }
+
+    @Override
+    public String combineTokens(List<Token> tokens) {
+        return helper.combineTokens(tokens);
+    }
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/JapaneseLanguageModel.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/JapaneseLanguageModel.java
@@ -9,7 +9,6 @@ import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 
 public final class JapaneseLanguageModel implements LanguageModel, AutoCloseable {
     /**
@@ -144,6 +143,11 @@ public final class JapaneseLanguageModel implements LanguageModel, AutoCloseable
         }
 
         return tokens;
+    }
+
+    @Override
+    public String combineTokens(List<Token> tokens) {
+        return String.join("", tokens.stream().map(Token::value).toList());
     }
 
     private String normalizeString(String input) {

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/JapaneseModifiedHepburnLanguageModel.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/JapaneseModifiedHepburnLanguageModel.java
@@ -23,4 +23,9 @@ public final class JapaneseModifiedHepburnLanguageModel implements LanguageModel
     public List<Token> tokenize(String input) {
         return helper.tokenize(input);
     }
+
+    @Override
+    public String combineTokens(List<Token> tokens) {
+        return helper.combineTokens(tokens);
+    }
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/LanguageModel.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/LanguageModel.java
@@ -14,6 +14,8 @@ public sealed interface LanguageModel permits EnglishLanguageModel, FrenchLangua
 
     List<Token> tokenize(String sentence);
 
+    String combineTokens(List<Token> tokens);
+
     static Map<Language, LanguageModel> languageModels = Map.of(
             Language.English, new EnglishLanguageModel(),
             Language.French, new FrenchLanguageModel(),

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/SwedishLanguageModel.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/SwedishLanguageModel.java
@@ -27,4 +27,9 @@ public final class SwedishLanguageModel implements LanguageModel {
     public List<Token> tokenize(String input) {
         return helper.tokenize(input);
     }
+
+    @Override
+    public String combineTokens(List<Token> tokens) {
+        return helper.combineTokens(tokens);
+    }
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/TurkishLanguageModel.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/TurkishLanguageModel.java
@@ -30,4 +30,9 @@ public final class TurkishLanguageModel implements LanguageModel {
     public List<Token> tokenize(String input) {
         return helper.tokenize(input);
     }
+
+    @Override
+    public String combineTokens(List<Token> tokens) {
+        return helper.combineTokens(tokens);
+    }
 }

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/EnglishLanguageModelTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/EnglishLanguageModelTest.java
@@ -6,6 +6,9 @@ import com.munetmo.lingetic.LanguageService.Entities.TokenType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class EnglishLanguageModelTest {
@@ -243,17 +246,17 @@ class EnglishLanguageModelTest {
     @Test
     void tokenizeShouldAssignCorrectSequenceNumbers() {
         var tokens = model.tokenize("Hello, world!");
-        
+
         assertEquals(4, tokens.size());
-        
+
         for (int i = 0; i < tokens.size(); i++) {
-            assertEquals(i + 1, tokens.get(i).sequenceNumber(), 
+            assertEquals(i + 1, tokens.get(i).sequenceNumber(),
                 "Token at position " + i + " should have sequence number " + (i + 1));
         }
-        
+
         // Test with a more complex sentence
         tokens = model.tokenize("I'll see you when you've finished!");
-        
+
         assertEquals(7, tokens.size());
         assertEquals(1, tokens.get(0).sequenceNumber()); // I'll
         assertEquals(2, tokens.get(1).sequenceNumber()); // see
@@ -267,7 +270,7 @@ class EnglishLanguageModelTest {
     @Test
     void tokenizeShouldAssignSequentialNumbersWithPunctuation() {
         var tokens = model.tokenize("Hello! What's up?");
-        
+
         assertEquals(5, tokens.size());
         assertEquals(1, tokens.get(0).sequenceNumber()); // Hello
         assertEquals(2, tokens.get(1).sequenceNumber()); // !
@@ -275,4 +278,78 @@ class EnglishLanguageModelTest {
         assertEquals(4, tokens.get(3).sequenceNumber()); // up
         assertEquals(5, tokens.get(4).sequenceNumber()); // ?
     }
+
+    @Test
+    void combineTokensShouldHandleEmptyList() {
+        assertEquals("", model.combineTokens(List.of()));
+    }
+
+    @Test
+    void combineTokensShouldHandleSimpleSentence() {
+        var tokens = Arrays.asList(
+            new Token(TokenType.Word, "Hello", 1),
+            new Token(TokenType.Punctuation, ",", 2),
+            new Token(TokenType.Word, "world", 3),
+            new Token(TokenType.Punctuation, "!", 4)
+        );
+        assertEquals("Hello, world!", model.combineTokens(tokens));
+    }
+
+    @Test
+    void combineTokensShouldHandleNumbersAndPunctuation() {
+        var tokens = Arrays.asList(
+            new Token(TokenType.Word, "I", 1),
+            new Token(TokenType.Word, "have", 2),
+            new Token(TokenType.Number, "42", 3),
+            new Token(TokenType.Word, "apples", 4),
+            new Token(TokenType.Punctuation, ".", 5)
+        );
+        assertEquals("I have 42 apples.", model.combineTokens(tokens));
+    }
+
+    @Test
+    void combineTokensShouldHandleContractionsAndApostrophes() {
+        var tokens = Arrays.asList(
+            new Token(TokenType.Word, "I'm", 1),
+            new Token(TokenType.Word, "don't", 2),
+            new Token(TokenType.Word, "know", 3),
+            new Token(TokenType.Punctuation, ".", 4)
+        );
+        assertEquals("I'm don't know.", model.combineTokens(tokens));
+    }
+
+    @Test
+    void combineTokensShouldHandleMultipleSentences() {
+        var tokens = Arrays.asList(
+            new Token(TokenType.Word, "Hello", 1),
+            new Token(TokenType.Punctuation, ".", 2),
+            new Token(TokenType.Word, "How", 3),
+            new Token(TokenType.Word, "are", 4),
+            new Token(TokenType.Word, "you", 5),
+            new Token(TokenType.Punctuation, "?", 6),
+            new Token(TokenType.Word, "I", 7),
+            new Token(TokenType.Word, "am", 8),
+            new Token(TokenType.Word, "fine", 9),
+            new Token(TokenType.Punctuation, "!", 10)
+        );
+        assertEquals("Hello. How are you? I am fine!", model.combineTokens(tokens));
+    }
+
+    @Test
+    void combineTokensShouldHandleNestedPunctuation() {
+        var tokens = Arrays.asList(
+            new Token(TokenType.Word, "He", 1),
+            new Token(TokenType.Word, "said", 2),
+            new Token(TokenType.Punctuation, ",", 3),
+            new Token(TokenType.Punctuation, "\"", 4),
+            new Token(TokenType.Word, "Hello", 5),
+            new Token(TokenType.Punctuation, ",", 6),
+            new Token(TokenType.Word, "world", 7),
+            new Token(TokenType.Punctuation, "!", 8),
+            new Token(TokenType.Punctuation, "\"", 9)
+        );
+        assertEquals("He said, \"Hello, world!\"", model.combineTokens(tokens));
+    }
 }
+
+

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/FrenchLanguageModelTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/FrenchLanguageModelTest.java
@@ -7,6 +7,9 @@ import com.munetmo.lingetic.LanguageService.Entities.TokenType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class FrenchLanguageModelTest {
@@ -256,73 +259,73 @@ class FrenchLanguageModelTest {
     @Test
     void tokenizeShouldHandleFrenchGuillemets() {
         var tokens = frenchLanguageModel.tokenize("« Bonjour le monde ! »");
-        
+
         assertEquals(6, tokens.size());
-        
+
         assertEquals(TokenType.Punctuation, tokens.get(0).type());
         assertEquals("«", tokens.get(0).value());
-        
+
         assertEquals(TokenType.Word, tokens.get(1).type());
         assertEquals("Bonjour", tokens.get(1).value());
-        
+
         assertEquals(TokenType.Word, tokens.get(2).type());
         assertEquals("le", tokens.get(2).value());
-        
+
         assertEquals(TokenType.Word, tokens.get(3).type());
         assertEquals("monde", tokens.get(3).value());
-        
+
         assertEquals(TokenType.Punctuation, tokens.get(4).type());
         assertEquals("!", tokens.get(4).value());
-        
+
         assertEquals(TokenType.Punctuation, tokens.get(5).type());
         assertEquals("»", tokens.get(5).value());
     }
-    
+
     @Test
     void tokenizeShouldHandleNestedQuotations() {
         var tokens = frenchLanguageModel.tokenize("Elle a dit : « Il m'a répondu \"Je ne sais pas\" hier. »");
-        
+
         assertEquals(17, tokens.size());
-        
+
         assertEquals(TokenType.Word, tokens.get(0).type());
         assertEquals("Elle", tokens.get(0).value());
-        
+
         assertEquals(TokenType.Word, tokens.get(1).type());
         assertEquals("a", tokens.get(1).value());
-        
+
         assertEquals(TokenType.Word, tokens.get(2).type());
         assertEquals("dit", tokens.get(2).value());
-        
+
         assertEquals(TokenType.Punctuation, tokens.get(3).type());
         assertEquals(":", tokens.get(3).value());
-        
+
         assertEquals(TokenType.Punctuation, tokens.get(4).type());
         assertEquals("«", tokens.get(4).value());
-        
+
         assertEquals(TokenType.Word, tokens.get(5).type());
         assertEquals("Il", tokens.get(5).value());
-        
+
         assertEquals(TokenType.Word, tokens.get(6).type());
         assertEquals("m'a", tokens.get(6).value());
-        
+
         assertEquals(TokenType.Word, tokens.get(7).type());
         assertEquals("répondu", tokens.get(7).value());
-        
+
         assertEquals(TokenType.Punctuation, tokens.get(8).type());
         assertEquals("\"", tokens.get(8).value());
-        
+
         assertEquals(TokenType.Word, tokens.get(9).type());
         assertEquals("Je", tokens.get(9).value());
-        
+
         assertEquals(TokenType.Word, tokens.get(10).type());
         assertEquals("ne", tokens.get(10).value());
-        
+
         assertEquals(TokenType.Word, tokens.get(11).type());
         assertEquals("sais", tokens.get(11).value());
-        
+
         assertEquals(TokenType.Word, tokens.get(12).type());
         assertEquals("pas", tokens.get(12).value());
-        
+
         assertEquals(TokenType.Punctuation, tokens.get(13).type());
         assertEquals("\"", tokens.get(13).value());
 
@@ -374,17 +377,17 @@ class FrenchLanguageModelTest {
     @Test
     void tokenizeShouldAssignCorrectSequenceNumbers() {
         var tokens = frenchLanguageModel.tokenize("Bonjour, monde!");
-        
+
         assertEquals(4, tokens.size());
-        
+
         for (int i = 0; i < tokens.size(); i++) {
-            assertEquals(i + 1, tokens.get(i).sequenceNumber(), 
+            assertEquals(i + 1, tokens.get(i).sequenceNumber(),
                 "Token at position " + i + " should have sequence number " + (i + 1));
         }
-        
+
         // Test with a more complex sentence
         tokens = frenchLanguageModel.tokenize("J'ai besoin d'aide!");
-        
+
         assertEquals(4, tokens.size());
         assertEquals(1, tokens.get(0).sequenceNumber()); // J'ai
         assertEquals(2, tokens.get(1).sequenceNumber()); // besoin
@@ -395,12 +398,86 @@ class FrenchLanguageModelTest {
     @Test
     void tokenizeShouldAssignSequentialNumbersWithPunctuation() {
         var tokens = frenchLanguageModel.tokenize("Salut! Ça va?");
-        
+
         assertEquals(5, tokens.size());
         assertEquals(1, tokens.get(0).sequenceNumber()); // Salut
         assertEquals(2, tokens.get(1).sequenceNumber()); // !
         assertEquals(3, tokens.get(2).sequenceNumber()); // Ça
         assertEquals(4, tokens.get(3).sequenceNumber()); // va
         assertEquals(5, tokens.get(4).sequenceNumber()); // ?
+    }
+
+    @Test
+    void combineTokensShouldHandleEmptyList() {
+        assertEquals("", frenchLanguageModel.combineTokens(List.of()));
+    }
+
+    @Test
+    void combineTokensShouldHandleSimpleSentence() {
+        var tokens = Arrays.asList(
+            new Token(TokenType.Word, "Bonjour", 1),
+            new Token(TokenType.Punctuation, ",", 2),
+            new Token(TokenType.Word, "monde", 3),
+            new Token(TokenType.Punctuation, "!", 4)
+        );
+        assertEquals("Bonjour, monde!", frenchLanguageModel.combineTokens(tokens));
+    }
+
+    @Test
+    void combineTokensShouldHandleContractionsAndQuotations() {
+        var tokens = Arrays.asList(
+            new Token(TokenType.Word, "J'aime", 1),
+            new Token(TokenType.Word, "l'école", 2),
+            new Token(TokenType.Punctuation, "«", 3),
+            new Token(TokenType.Word, "C'est", 4),
+            new Token(TokenType.Word, "parfait", 5),
+            new Token(TokenType.Punctuation, "»", 6)
+        );
+        assertEquals("J'aime l'école «C'est parfait»", frenchLanguageModel.combineTokens(tokens));
+    }
+
+    @Test
+    void combineTokensShouldHandleNumbersAndAccents() {
+        var tokens = Arrays.asList(
+            new Token(TokenType.Word, "Il", 1),
+            new Token(TokenType.Word, "y", 2),
+            new Token(TokenType.Word, "a", 3),
+            new Token(TokenType.Number, "42", 4),
+            new Token(TokenType.Word, "élèves", 5),
+            new Token(TokenType.Punctuation, ".", 6)
+        );
+        assertEquals("Il y a 42 élèves.", frenchLanguageModel.combineTokens(tokens));
+    }
+
+    @Test
+    void combineTokensShouldHandleMultipleSentences() {
+        var tokens = Arrays.asList(
+            new Token(TokenType.Word, "Bonjour", 1),
+            new Token(TokenType.Punctuation, ".", 2),
+            new Token(TokenType.Word, "Comment", 3),
+            new Token(TokenType.Word, "allez-vous", 4),
+            new Token(TokenType.Punctuation, "?", 5),
+            new Token(TokenType.Word, "Je", 6),
+            new Token(TokenType.Word, "vais", 7),
+            new Token(TokenType.Word, "bien", 8),
+            new Token(TokenType.Punctuation, "!", 9)
+        );
+        assertEquals("Bonjour. Comment allez-vous? Je vais bien!", frenchLanguageModel.combineTokens(tokens));
+    }
+
+    @Test
+    void combineTokensShouldHandleNestedPunctuation() {
+        var tokens = Arrays.asList(
+            new Token(TokenType.Word, "Il", 1),
+            new Token(TokenType.Word, "dit", 2),
+            new Token(TokenType.Punctuation, ",", 3),
+            new Token(TokenType.Punctuation, "«", 4),
+            new Token(TokenType.Word, "Bonjour", 5),
+            new Token(TokenType.Punctuation, ",", 6),
+            new Token(TokenType.Word, "monde", 7),
+            new Token(TokenType.Punctuation, "!", 8),
+            new Token(TokenType.Punctuation, "»", 9)
+        );
+        assertEquals("Il dit, «Bonjour, monde!»", frenchLanguageModel.combineTokens(tokens));
     }
 }

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/JapaneseLanguageModelTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/JapaneseLanguageModelTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -155,5 +156,69 @@ class JapaneseLanguageModelTest {
         assertEquals("使い", tokens.get(2).value());
         assertEquals("ます", tokens.get(3).value());
         assertEquals("。", tokens.get(4).value());
+    }
+
+    @Test
+    void combineTokensShouldHandleEmptyList() {
+        assertEquals("", model.combineTokens(List.of()));
+    }
+
+    @Test
+    void combineTokensShouldHandleSimpleSentence() {
+        var tokens = Arrays.asList(
+            new Token(TokenType.Word, "私", 1),
+            new Token(TokenType.Word, "は", 2),
+            new Token(TokenType.Word, "学生", 3),
+            new Token(TokenType.Word, "です", 4),
+            new Token(TokenType.Punctuation, "。", 5)
+        );
+        assertEquals("私は学生です。", model.combineTokens(tokens));
+    }
+
+    @Test
+    void combineTokensShouldHandleNumbersWithSpace() {
+        var tokens = Arrays.asList(
+            new Token(TokenType.Word, "クラス", 1),
+            new Token(TokenType.Word, "に", 2),
+            new Token(TokenType.Number, "42", 3),
+            new Token(TokenType.Word, "人", 4),
+            new Token(TokenType.Word, "います", 5),
+            new Token(TokenType.Punctuation, "。", 6)
+        );
+
+        assertEquals("クラスに42人います。", model.combineTokens(tokens));
+    }
+
+    @Test
+    void combineTokensShouldHandleMixedScriptsAndPunctuation() {
+        var tokens = Arrays.asList(
+            new Token(TokenType.Word, "彼", 1),
+            new Token(TokenType.Word, "は", 2),
+            new Token(TokenType.Word, "Java", 3),
+            new Token(TokenType.Word, "プログラマー", 4),
+            new Token(TokenType.Word, "です", 5),
+            new Token(TokenType.Punctuation, "。", 6)
+        );
+
+        assertEquals("彼はJavaプログラマーです。", model.combineTokens(tokens));
+    }
+
+    @Test
+    void combineTokensShouldHandleMultipleSentences() {
+        var tokens = Arrays.asList(
+            new Token(TokenType.Word, "おはよう", 1),
+            new Token(TokenType.Punctuation, "。", 2),
+            new Token(TokenType.Word, "お", 3),
+            new Token(TokenType.Word, "元気", 4),
+            new Token(TokenType.Word, "です", 5),
+            new Token(TokenType.Word, "か", 6),
+            new Token(TokenType.Punctuation, "？", 7),
+            new Token(TokenType.Word, "はい", 8),
+            new Token(TokenType.Punctuation, "、", 9),
+            new Token(TokenType.Word, "元気", 10),
+            new Token(TokenType.Word, "です", 11),
+            new Token(TokenType.Punctuation, "。", 12)
+        );
+        assertEquals("おはよう。お元気ですか？はい、元気です。", model.combineTokens(tokens));
     }
 }

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/JapaneseModifiedHepburnLanguageModelTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/JapaneseModifiedHepburnLanguageModelTest.java
@@ -1,9 +1,13 @@
 package com.munetmo.lingetic.LanguageService.Entities.LanguageModels;
 
 import com.munetmo.lingetic.LanguageService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.Token;
 import com.munetmo.lingetic.LanguageService.Entities.TokenType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -251,5 +255,85 @@ class JapaneseModifiedHepburnLanguageModelTest {
         assertEquals("ka", tokens.get(5).value());
         assertEquals(TokenType.Punctuation, tokens.get(6).type());
         assertEquals("?", tokens.get(6).value());
+    }
+
+    @Test
+    void combineTokensShouldHandleEmptyList() {
+        assertEquals("", model.combineTokens(List.of()));
+    }
+
+    @Test
+    void combineTokensShouldHandleSimpleSentence() {
+        var tokens = Arrays.asList(
+            new Token(TokenType.Word, "Watashi", 1),
+            new Token(TokenType.Word, "wa", 2),
+            new Token(TokenType.Word, "gakusei", 3),
+            new Token(TokenType.Word, "desu", 4),
+            new Token(TokenType.Punctuation, ".", 5)
+        );
+        assertEquals("Watashi wa gakusei desu.", model.combineTokens(tokens));
+    }
+
+    @Test
+    void combineTokensShouldHandleMacrons() {
+        var tokens = Arrays.asList(
+            new Token(TokenType.Word, "Tōkyō", 1),
+            new Token(TokenType.Word, "wa", 2),
+            new Token(TokenType.Word, "ōkii", 3),
+            new Token(TokenType.Word, "desu", 4),
+            new Token(TokenType.Punctuation, ".", 5)
+        );
+        assertEquals("Tōkyō wa ōkii desu.", model.combineTokens(tokens));
+    }
+
+    @Test
+    void combineTokensShouldHandleQuotationsAndNumbers() {
+        var tokens = Arrays.asList(
+            new Token(TokenType.Word, "Sensei", 1),
+            new Token(TokenType.Word, "wa", 2),
+            new Token(TokenType.Punctuation, "\"", 3),
+            new Token(TokenType.Number, "42", 4),
+            new Token(TokenType.Word, "desu", 5),
+            new Token(TokenType.Punctuation, "\"", 6),
+            new Token(TokenType.Word, "to", 7),
+            new Token(TokenType.Word, "iimashita", 8),
+            new Token(TokenType.Punctuation, ".", 9)
+        );
+        assertEquals("Sensei wa \"42 desu\" to iimashita.", model.combineTokens(tokens));
+    }
+
+    @Test
+    void combineTokensShouldHandleMultipleSentences() {
+        var tokens = Arrays.asList(
+            new Token(TokenType.Word, "Ohayō", 1),
+            new Token(TokenType.Punctuation, ".", 2),
+            new Token(TokenType.Word, "Ogenki", 3),
+            new Token(TokenType.Word, "desu", 4),
+            new Token(TokenType.Word, "ka", 5),
+            new Token(TokenType.Punctuation, "?", 6),
+            new Token(TokenType.Word, "Hai", 7),
+            new Token(TokenType.Punctuation, ",", 8),
+            new Token(TokenType.Word, "genki", 9),
+            new Token(TokenType.Word, "desu", 10),
+            new Token(TokenType.Punctuation, ".", 11)
+        );
+        assertEquals("Ohayō. Ogenki desu ka? Hai, genki desu.", model.combineTokens(tokens));
+    }
+
+    @Test
+    void combineTokensShouldHandleNestedPunctuation() {
+        var tokens = Arrays.asList(
+            new Token(TokenType.Word, "Kare", 1),
+            new Token(TokenType.Word, "wa", 2),
+            new Token(TokenType.Word, "iimashita", 3),
+            new Token(TokenType.Punctuation, ",", 4),
+            new Token(TokenType.Punctuation, "\"", 5),
+            new Token(TokenType.Word, "Konnichiwa", 6),
+            new Token(TokenType.Punctuation, ",", 7),
+            new Token(TokenType.Word, "sekai", 8),
+            new Token(TokenType.Punctuation, "!", 9),
+            new Token(TokenType.Punctuation, "\"", 10)
+        );
+        assertEquals("Kare wa iimashita, \"Konnichiwa, sekai!\"", model.combineTokens(tokens));
     }
 }

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/SwedishLanguageModelTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageService/Entities/LanguageModels/SwedishLanguageModelTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -193,5 +194,77 @@ class SwedishLanguageModelTest {
     void testEquivalentWithOnlyNumbers() {
         assertTrue(model.areEquivalent("123", "123"));
         assertFalse(model.areEquivalent("123", "321"));
+    }
+
+    @Test
+    void combineTokensShouldHandleEmptyList() {
+        assertEquals("", model.combineTokens(List.of()));
+    }
+
+    @Test
+    void combineTokensShouldHandleSimpleSentence() {
+        var tokens = Arrays.asList(
+            new Token(TokenType.Word, "Hej", 1),
+            new Token(TokenType.Punctuation, ",", 2),
+            new Token(TokenType.Word, "världen", 3),
+            new Token(TokenType.Punctuation, "!", 4)
+        );
+        assertEquals("Hej, världen!", model.combineTokens(tokens));
+    }
+
+    @Test
+    void combineTokensShouldHandleSwedishCharacters() {
+        var tokens = Arrays.asList(
+            new Token(TokenType.Word, "Får", 1),
+            new Token(TokenType.Word, "äter", 2),
+            new Token(TokenType.Word, "hö", 3),
+            new Token(TokenType.Punctuation, ".", 4)
+        );
+        assertEquals("Får äter hö.", model.combineTokens(tokens));
+    }
+
+    @Test
+    void combineTokensShouldHandleNumbersAndPunctuation() {
+        var tokens = Arrays.asList(
+            new Token(TokenType.Word, "Jag", 1),
+            new Token(TokenType.Word, "har", 2),
+            new Token(TokenType.Number, "42", 3),
+            new Token(TokenType.Word, "äpplen", 4),
+            new Token(TokenType.Punctuation, ".", 5)
+        );
+        assertEquals("Jag har 42 äpplen.", model.combineTokens(tokens));
+    }
+
+    @Test
+    void combineTokensShouldHandleMultipleSentences() {
+        var tokens = Arrays.asList(
+            new Token(TokenType.Word, "Hej", 1),
+            new Token(TokenType.Punctuation, ".", 2),
+            new Token(TokenType.Word, "Hur", 3),
+            new Token(TokenType.Word, "mår", 4),
+            new Token(TokenType.Word, "du", 5),
+            new Token(TokenType.Punctuation, "?", 6),
+            new Token(TokenType.Word, "Jag", 7),
+            new Token(TokenType.Word, "mår", 8),
+            new Token(TokenType.Word, "bra", 9),
+            new Token(TokenType.Punctuation, "!", 10)
+        );
+        assertEquals("Hej. Hur mår du? Jag mår bra!", model.combineTokens(tokens));
+    }
+
+    @Test
+    void combineTokensShouldHandleNestedPunctuation() {
+        var tokens = Arrays.asList(
+            new Token(TokenType.Word, "Han", 1),
+            new Token(TokenType.Word, "sa", 2),
+            new Token(TokenType.Punctuation, ",", 3),
+            new Token(TokenType.Punctuation, "\"", 4),
+            new Token(TokenType.Word, "Hej", 5),
+            new Token(TokenType.Punctuation, ",", 6),
+            new Token(TokenType.Word, "världen", 7),
+            new Token(TokenType.Punctuation, "!", 8),
+            new Token(TokenType.Punctuation, "\"", 9)
+        );
+        assertEquals("Han sa, \"Hej, världen!\"", model.combineTokens(tokens));
     }
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Added a combineTokens method to all language models, allowing tokens to be joined back into a string. Includes full test coverage for each language.

- **New Features**
  - Added combineTokens to LanguageModel and all implementations.
  - Implemented logic for combining tokens, handling punctuation and spacing.
  - Added tests for combineTokens in all language model test files.

<!-- End of auto-generated description by mrge. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to reconstruct sentences from tokens for English, French, Japanese, Japanese Modified Hepburn, Swedish, and Turkish language models.
- **Bug Fixes**
  - Improved handling of spacing and punctuation when combining tokens into sentences.
- **Tests**
  - Introduced comprehensive tests to ensure accurate sentence reconstruction across all supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->