### PR TITLE
Disable the Japanese 2 course

### DIFF
--- a/lingetic-nextjs-frontend/app/languages/constants.ts
+++ b/lingetic-nextjs-frontend/app/languages/constants.ts
@@ -58,7 +58,7 @@ export const languages: LanguageProperty[] = [
     id: "Japanese",
     name: "Japanese 2",
     image: "/img/languages/japanese-flag.png",
-    isSupported: true,
+    isSupported: false,
   },
   {
     id: "Korean",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Disabled the Japanese 2 course so it no longer appears as an available option.

<!-- End of auto-generated description by mrge. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the support status of the "Japanese 2" language variant, marking it as unsupported in the language selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->