### PR TITLE
Use startIndex to render explanation interleaved with the rest of the sentence

### DIFF
--- a/lingetic-nextjs-frontend/app/components/questions/FillInTheBlanks/Result.tsx
+++ b/lingetic-nextjs-frontend/app/components/questions/FillInTheBlanks/Result.tsx
@@ -1,4 +1,7 @@
-import type { FillInTheBlanksAttemptResponse } from "@/utilities/api-types";
+import type {
+  FillInTheBlanksAttemptResponse,
+  WordExplanation,
+} from "@/utilities/api-types";
 import WordExplanationHover from "./WordExplanationHover";
 import type { FillInTheBlanksQuestion } from "@/utilities/api-types";
 
@@ -11,26 +14,66 @@ export default function ResultBox({
   question,
   attemptResponse,
 }: ResultBoxProps) {
-  if (attemptResponse.explanation.length === 0) {
-    const fullSentence = question.text.replace(
-      /_+/,
-      attemptResponse.correctAnswer
-    );
-    return <div>{fullSentence}</div>;
-  }
+  const fullSentence = question.text.replace(
+    /_+/,
+    attemptResponse.correctAnswer
+  );
+
+  const parts = getSentenceParts(fullSentence, attemptResponse.explanation);
 
   return (
-    <div className="flex flex-wrap gap-1">
-      {attemptResponse.explanation
-        .slice()
-        .sort((a, b) => a.startIndex - b.startIndex)
-        .map((exp) => (
+    <div className="flex flex-wrap items-center whitespace-pre-wrap">
+      {parts.map((part, idx) =>
+        part.explanation ? (
           <WordExplanationHover
-            key={exp.startIndex}
-            word={exp.word}
-            explanation={exp}
+            key={idx}
+            word={part.text}
+            explanation={part.explanation}
           />
-        ))}
+        ) : (
+          <span key={idx}>{part.text}</span>
+        )
+      )}
     </div>
   );
+}
+
+interface SentencePart {
+  text: string;
+  explanation?: WordExplanation;
+}
+
+function getSentenceParts(
+  fullSentence: string,
+  explanations: WordExplanation[]
+): SentencePart[] {
+  const sortedExplanations = explanations.toSorted(
+    (a, b) => a.startIndex - b.startIndex
+  );
+
+  const parts: SentencePart[] = [];
+
+  let lastIndex = 0;
+  sortedExplanations.forEach((explanation) => {
+    if (explanation.startIndex > lastIndex) {
+      parts.push({
+        text: fullSentence.slice(lastIndex, explanation.startIndex),
+      });
+    }
+
+    parts.push({
+      text: explanation.word,
+      explanation,
+    });
+
+    lastIndex = explanation.startIndex + explanation.word.length;
+  });
+
+  if (lastIndex < fullSentence.length) {
+    parts.push({
+      text: fullSentence.slice(lastIndex),
+    });
+  }
+
+  return parts;
 }

--- a/lingetic-nextjs-frontend/app/components/questions/FillInTheBlanks/WordExplanationHover.tsx
+++ b/lingetic-nextjs-frontend/app/components/questions/FillInTheBlanks/WordExplanationHover.tsx
@@ -8,11 +8,13 @@ import type { WordExplanation } from "@/utilities/api-types";
 interface WordExplanationHoverProps {
   word: string;
   explanation: WordExplanation;
+  className?: string;
 }
 
 export default function WordExplanationHover({
   word,
   explanation,
+  className,
 }: WordExplanationHoverProps) {
   const [open, setOpen] = useState(false);
   const { refs, floatingStyles } = useFloating({
@@ -23,7 +25,7 @@ export default function WordExplanationHover({
 
   return (
     <span
-      className="relative cursor-pointer px-2 py-1 rounded bg-skin-fill-accent hover:bg-skin-fill-accent/70 transition-colors mx-1"
+      className={`cursor-pointer ${className ?? ""}`}
       ref={refs.setReference}
       onMouseEnter={() => setOpen(true)}
       onMouseLeave={() => setOpen(false)}
@@ -31,7 +33,7 @@ export default function WordExplanationHover({
       onFocus={() => setOpen(true)}
       onBlur={() => setOpen(false)}
     >
-      <span className="border-b-[2.5px] border-dotted border-skin-base text-skin-base">
+      <span className="border-b-[0.5px] border-dotted border-skin-base text-skin-base">
         {word}
       </span>
       {open && (


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Updated the fill-in-the-blanks result view to show word explanations interleaved within the sentence, using each word’s start index for accurate placement.

- **UI Improvements**
  - Explanations now appear in the correct position in the sentence, instead of grouped at the end.
  - Improved styling for words with explanations.

<!-- End of auto-generated description by mrge. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the rendering logic for fill-in-the-blank results, ensuring consistent display of sentences with or without word explanations.
  - Enhanced sentence segmentation to better interleave explanatory and non-explanatory text.

- **Style**
  - Adjusted the underline thickness for explained words to improve visual clarity.

- **New Features**
  - Added support for custom styling of word explanations via an optional class name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->