### PR TITLE
Prefetch questions before replay

### DIFF
--- a/lingetic-nextjs-frontend/app/languages/[language]/useQuestions.ts
+++ b/lingetic-nextjs-frontend/app/languages/[language]/useQuestions.ts
@@ -63,20 +63,11 @@ export default function useQuestions({
     isSuccess,
   } = useQuery({
     queryKey: ["questions", language],
-    queryFn: async () => {
-      const questions = await fetchQuestions(language, getToken);
-      // Shuffle the questions using Fisher-Yates algorithm
-      for (let i = questions.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [questions[i], questions[j]] = [questions[j], questions[i]];
-      }
-      return questions;
-    },
+    queryFn: () => fetchQuestions(language, getToken),
 
-    // The same questions should not be displayed on different renders
-    // of the component. This is because the questions that Lingetic thinks
-    // the user should attempt may change any time.
-    refetchOnMount: "always",
+    // Don't refetch as questions have been prefetched on the results page
+    refetchOnMount: false,
+    refetchOnReconnect: false,
 
     // If user navigates away from the page in between a run of a playlist,
     // the playlist shouldn't refresh and change the questions the user was

--- a/lingetic-nextjs-frontend/utilities/api.ts
+++ b/lingetic-nextjs-frontend/utilities/api.ts
@@ -6,6 +6,7 @@ import type {
   AssetType,
 } from "./api-types";
 import assert from "./assert";
+import { shuffleInPlace } from "./helpers";
 
 async function fetchOrThrow<T>(url: string, options?: RequestInit): Promise<T> {
   const response = await fetch(url, options);
@@ -55,11 +56,15 @@ export async function fetchQuestions(
   const encodedLanguage = encodeURIComponent(language);
   const url = `${process.env.NEXT_PUBLIC_API_BASE_URL}/language-test-service/questions?language=${encodedLanguage}`;
 
-  return await fetchOrThrow(url, {
+  const questions = await fetchOrThrow<Question[]>(url, {
     headers: {
       Authorization: `Bearer ${token}`,
     },
   });
+
+  shuffleInPlace(questions);
+
+  return questions;
 }
 
 export async function fetchQuestionAsset(

--- a/lingetic-nextjs-frontend/utilities/helpers.ts
+++ b/lingetic-nextjs-frontend/utilities/helpers.ts
@@ -1,0 +1,6 @@
+export function shuffleInPlace<T>(array: T[]) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a utility function to shuffle arrays in place, enhancing randomization of question order.

- **Improvements**
  - Questions are now shuffled after fetching, ensuring a randomized experience for each session.
  - Optimized question data fetching and caching for improved performance and reliability.
  - Updated data prefetching logic to better prepare questions for subsequent rounds.

- **Bug Fixes**
  - Adjusted data fetching behavior to prevent unnecessary refetching, reducing redundant network requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->