### PR TITLE
05 15 add sourcetotargettranslation question type to backend

### DIFF
--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptRequests/AttemptRequest.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptRequests/AttemptRequest.java
@@ -6,7 +6,7 @@ import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
 import com.munetmo.lingetic.LanguageTestService.infra.Deserializers.AttemptRequestDeserializer;
 
 @JsonDeserialize(using = AttemptRequestDeserializer.class)
-public sealed interface AttemptRequest permits FillInTheBlanksAttemptRequest {
+public sealed interface AttemptRequest permits FillInTheBlanksAttemptRequest, SourceToTargetTranslationAttemptRequest {
     QuestionType getQuestionType();
     String getQuestionID();
 
@@ -20,6 +20,7 @@ public sealed interface AttemptRequest permits FillInTheBlanksAttemptRequest {
 
         return switch (type) {
             case FillInTheBlanks -> FillInTheBlanksAttemptRequest.fromJsonNode(node);
+            case SourceToTargetTranslation -> SourceToTargetTranslationAttemptRequest.fromJsonNode(node);
         };
     }
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptRequests/SourceToTargetTranslationAttemptRequest.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptRequests/SourceToTargetTranslationAttemptRequest.java
@@ -1,0 +1,47 @@
+package com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
+
+public final class SourceToTargetTranslationAttemptRequest implements AttemptRequest {
+    private final String questionID;
+    private final String userResponse;
+
+    public SourceToTargetTranslationAttemptRequest(String questionID, String userResponse) {
+        if (questionID.isBlank()) {
+            throw new IllegalArgumentException("questionID must not be blank");
+        }
+
+        this.questionID = questionID;
+        this.userResponse = userResponse;
+    }
+
+    @Override
+    public String getQuestionID() {
+        return questionID;
+    }
+
+    @Override
+    public QuestionType getQuestionType() {
+        return QuestionType.SourceToTargetTranslation;
+    }
+
+    public String getUserResponse() {
+        return userResponse;
+    }
+
+    static SourceToTargetTranslationAttemptRequest fromJsonNode(JsonNode node) {
+        if (!node.has("questionID")) {
+            throw new IllegalArgumentException("SourceToTargetTranslationAttemptRequest must have a questionID");
+        }
+
+        if (!node.has("userResponse")) {
+            throw new IllegalArgumentException("SourceToTargetTranslationAttemptRequest must have a userResponse");
+        }
+
+        return new SourceToTargetTranslationAttemptRequest(
+            node.get("questionID").asText(),
+            node.get("userResponse").asText()
+        );
+    }
+}

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptResponses/AttemptResponse.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptResponses/AttemptResponse.java
@@ -3,7 +3,7 @@ package com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses;
 import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
 
-public sealed interface AttemptResponse permits FillInTheBlanksAttemptResponse {
+public sealed interface AttemptResponse permits FillInTheBlanksAttemptResponse, SourceToTargetTranslationAttemptResponse {
     QuestionType getQuestionType();
     AttemptStatus getAttemptStatus();
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptResponses/SourceToTargetTranslationAttemptResponse.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptResponses/SourceToTargetTranslationAttemptResponse.java
@@ -1,0 +1,32 @@
+package com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses;
+
+import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
+import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
+
+public final class SourceToTargetTranslationAttemptResponse implements AttemptResponse {
+    private final AttemptStatus attemptStatus;
+    private final String correctAnswer;
+
+    public SourceToTargetTranslationAttemptResponse(AttemptStatus attemptStatus, String correctAnswer) {
+        if (correctAnswer.isBlank()) {
+            throw new IllegalArgumentException("correctAnswer cannot be blank.");
+        }
+
+        this.attemptStatus = attemptStatus;
+        this.correctAnswer = correctAnswer;
+    }
+
+    @Override
+    public QuestionType getQuestionType() {
+        return QuestionType.SourceToTargetTranslation;
+    }
+
+    @Override
+    public AttemptStatus getAttemptStatus() {
+        return attemptStatus;
+    }
+
+    public String getCorrectAnswer() {
+        return correctAnswer;
+    }
+}

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/QuestionDTO.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/QuestionDTO.java
@@ -4,8 +4,9 @@ import com.munetmo.lingetic.LanguageService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.FillInTheBlanksQuestion;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.Question;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
+import com.munetmo.lingetic.LanguageTestService.Entities.Questions.SourceToTargetTranslation;
 
-public sealed interface QuestionDTO permits FillInTheBlanksQuestionDTO {
+public sealed interface QuestionDTO permits FillInTheBlanksQuestionDTO, SourceToTargetTranslationDTO {
     String getID();
     QuestionType getQuestionType();
     Language getLanguage();
@@ -19,6 +20,14 @@ public sealed interface QuestionDTO permits FillInTheBlanksQuestionDTO {
                     typedQuestion.getLanguage(),
                     typedQuestion.questionText,
                     typedQuestion.hint
+                );
+            }
+            case SourceToTargetTranslation -> {
+                var typedQuestion = (SourceToTargetTranslation)question;
+                yield new SourceToTargetTranslationDTO(
+                    typedQuestion.getID(),
+                    typedQuestion.getLanguage(),
+                    typedQuestion.translation
                 );
             }
         };

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/SourceToTargetTranslationDTO.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/SourceToTargetTranslationDTO.java
@@ -1,0 +1,44 @@
+package com.munetmo.lingetic.LanguageTestService.DTOs.Question;
+
+import com.munetmo.lingetic.LanguageService.Entities.Language;
+import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
+
+public final class SourceToTargetTranslationDTO implements QuestionDTO {
+    public static final QuestionType questionType = QuestionType.SourceToTargetTranslation;
+    private final String id;
+    private final Language language;
+    public final String translation;
+
+    public SourceToTargetTranslationDTO(String id, Language language, String translation) {
+        if (id.isBlank()) {
+            throw new IllegalArgumentException("id must not be blank");
+        }
+
+        if (translation.isBlank()) {
+            throw new IllegalArgumentException("translation must not be blank");
+        }
+
+        this.id = id;
+        this.language = language;
+        this.translation = translation;
+    }
+
+    @Override
+    public String getID() {
+        return id;
+    }
+
+    @Override
+    public QuestionType getQuestionType() {
+        return questionType;
+    }
+
+    @Override
+    public Language getLanguage() {
+        return language;
+    }
+
+    public String getTranslation() {
+        return translation;
+    }
+}

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/Question.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/Question.java
@@ -6,7 +6,7 @@ import com.munetmo.lingetic.LanguageService.Entities.Language;
 
 import java.util.Map;
 
-public sealed interface Question permits FillInTheBlanksQuestion {
+public sealed interface Question permits FillInTheBlanksQuestion, SourceToTargetTranslation {
     String getID();
     QuestionType getQuestionType();
     Language getLanguage();
@@ -17,7 +17,7 @@ public sealed interface Question permits FillInTheBlanksQuestion {
     static Question createFromQuestionTypeSpecificData(String id, Language language, int difficulty, String questionListId, QuestionType questionType, Map<String, Object> data) {
         return switch (questionType) {
             case FillInTheBlanks -> FillInTheBlanksQuestion.createFromQuestionTypeSpecificData(id, language, difficulty, questionListId, data);
-            default -> throw new IllegalArgumentException("Unsupported question type");
+            case SourceToTargetTranslation -> SourceToTargetTranslation.createFromQuestionTypeSpecificData(id, language, difficulty, questionListId, data);
         };
     }
 

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/QuestionType.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/QuestionType.java
@@ -1,5 +1,6 @@
 package com.munetmo.lingetic.LanguageTestService.Entities.Questions;
 
 public enum QuestionType {
-    FillInTheBlanks
+    FillInTheBlanks,
+    SourceToTargetTranslation
 }

--- a/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/SourceToTargetTranslation.java
+++ b/lingetic-spring-backend/src/main/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/SourceToTargetTranslation.java
@@ -1,0 +1,108 @@
+package com.munetmo.lingetic.LanguageTestService.Entities.Questions;
+
+import com.munetmo.lingetic.LanguageService.Entities.Language;
+import com.munetmo.lingetic.LanguageService.Entities.LanguageModels.LanguageModel;
+import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests.AttemptRequest;
+import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.AttemptResponse;
+import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests.SourceToTargetTranslationAttemptRequest;
+import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.SourceToTargetTranslationAttemptResponse;
+import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
+
+import java.util.Map;
+
+public final class SourceToTargetTranslation implements Question {
+    private final String id;
+    private final Language language;
+    private final String questionListId;
+    private final static QuestionType questionType = QuestionType.SourceToTargetTranslation;
+
+    public final String targetText;  // The text in target language that user needs to type
+    public final String translation; // The English translation shown to user
+    public final int difficulty;
+
+    public SourceToTargetTranslation(String id, Language language, String targetText, String translation, int difficulty, String questionListId) {
+        if (id.isBlank()) {
+            throw new IllegalArgumentException("ID cannot be blank");
+        }
+
+        if (targetText.isBlank()) {
+            throw new IllegalArgumentException("Target text cannot be blank");
+        }
+
+        if (translation.isBlank()) {
+            throw new IllegalArgumentException("Translation cannot be blank");
+        }
+
+        if (questionListId.isBlank()) {
+            throw new IllegalArgumentException("Question list ID cannot be blank");
+        }
+
+        this.id = id;
+        this.language = language;
+        this.targetText = targetText;
+        this.translation = translation;
+        this.difficulty = difficulty;
+        this.questionListId = questionListId;
+    }
+
+    @Override
+    public String getID() {
+        return id;
+    }
+
+    @Override
+    public QuestionType getQuestionType() {
+        return questionType;
+    }
+
+    @Override
+    public Language getLanguage() {
+        return language;
+    }
+
+    @Override
+    public String getQuestionListID() {
+        return questionListId;
+    }
+
+    @Override
+    public int getDifficulty() {
+        return difficulty;
+    }
+
+    @Override
+    public AttemptResponse assessAttempt(AttemptRequest request) {
+        if (!(request instanceof SourceToTargetTranslationAttemptRequest typedRequest)) {
+            throw new IllegalArgumentException("Invalid request type");
+        }
+
+        var areEquivalent = LanguageModel.getLanguageModel(language).areEquivalent(
+            typedRequest.getUserResponse(),
+            targetText
+        );
+
+        return new SourceToTargetTranslationAttemptResponse(
+            areEquivalent ? AttemptStatus.Success : AttemptStatus.Failure,
+            targetText
+        );
+    }
+
+    @Override
+    public Map<String, Object> getQuestionTypeSpecificData() {
+        return Map.of(
+            "targetText", targetText,
+            "translation", translation
+        );
+    }
+
+    public static SourceToTargetTranslation createFromQuestionTypeSpecificData(String id, Language language, int difficulty, String questionListId, Map<String, Object> data) {
+        if (!data.containsKey("targetText") || !data.containsKey("translation")) {
+            throw new IllegalArgumentException("Required fields 'targetText' and 'translation' must be present in data");
+        }
+
+        var targetText = (String) data.get("targetText");
+        var translation = (String) data.get("translation");
+
+        return new SourceToTargetTranslation(id, language, targetText, translation, difficulty, questionListId);
+    }
+}

--- a/lingetic-spring-backend/src/main/resources/META-INF/native-image/com.munetmo/lingetic/reachability-metadata.json
+++ b/lingetic-spring-backend/src/main/resources/META-INF/native-image/com.munetmo/lingetic/reachability-metadata.json
@@ -299,6 +299,24 @@
       ]
     },
     {
+      "type": "com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.SourceToTargetTranslationAttemptResponse",
+      "allDeclaredFields": true,
+      "methods": [
+        {
+          "name": "getAttemptStatus",
+          "parameterTypes": []
+        },
+        {
+          "name": "getCorrectAnswer",
+          "parameterTypes": []
+        },
+        {
+          "name": "getQuestionType",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
       "type": "com.munetmo.lingetic.LanguageTestService.DTOs.Question.FillInTheBlanksQuestionDTO",
       "allDeclaredFields": true,
       "methods": [
@@ -330,6 +348,28 @@
     },
     {
       "type": "com.munetmo.lingetic.LanguageTestService.DTOs.Question.QuestionDTO"
+    },
+    {
+      "type": "com.munetmo.lingetic.LanguageTestService.DTOs.Question.SourceToTargetTranslationDTO",
+      "allDeclaredFields": true,
+      "methods": [
+        {
+          "name": "getID",
+          "parameterTypes": []
+        },
+        {
+          "name": "getLanguage",
+          "parameterTypes": []
+        },
+        {
+          "name": "getQuestionType",
+          "parameterTypes": []
+        },
+        {
+          "name": "getTranslation",
+          "parameterTypes": []
+        }
+      ]
     },
     {
       "type": "com.munetmo.lingetic.LanguageTestService.DTOs.TaskPayloads.GenericTaskPayloadWrapper",
@@ -8416,6 +8456,9 @@
     },
     {
       "glob": "db/migration/V7__Add_Japanese_Modified_Hepburn_Language.sql"
+    },
+    {
+      "glob": "db/migration/V8__Add_SourceToTargetTranslation_Question_Type.sql"
     },
     {
       "glob": "dictionaries/system_full.dic"

--- a/lingetic-spring-backend/src/main/resources/db/migration/V8__Add_SourceToTargetTranslation_Question_Type.sql
+++ b/lingetic-spring-backend/src/main/resources/db/migration/V8__Add_SourceToTargetTranslation_Question_Type.sql
@@ -1,0 +1,15 @@
+-- Migration script to add the SourceToTargetTranslation question type to the database
+CREATE TABLE IF NOT EXISTS question_types (
+    name TEXT PRIMARY KEY
+);
+
+-- Insert supported question types
+INSERT INTO question_types (name) VALUES
+    ('FillInTheBlanks'),
+    ('SourceToTargetTranslation');
+
+-- Drop existing question type check constraints
+ALTER TABLE questions DROP CONSTRAINT IF EXISTS questions_question_type_check;
+
+-- Add foreign key constraints
+ALTER TABLE questions ADD CONSTRAINT questions_question_type_fkey FOREIGN KEY (question_type) REFERENCES question_types (name);

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptRequests/AttemptRequestTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptRequests/AttemptRequestTest.java
@@ -61,4 +61,25 @@ class AttemptRequestTest {
         assertEquals("test answer", fillInBlanksRequest.getUserResponse());
         assertEquals(QuestionType.FillInTheBlanks, fillInBlanksRequest.getQuestionType());
     }
+
+    @Test
+    void shouldCreateSourceToTargetTranslationRequestWhenTypeMatches() throws JsonProcessingException {
+        var json = """
+            {
+                "questionType": "SourceToTargetTranslation",
+                "questionID": "123",
+                "userResponse": "test answer"
+            }
+            """;
+        var node = objectMapper.readTree(json);
+
+        var request = AttemptRequest.fromJsonNode(node);
+
+        assertInstanceOf(SourceToTargetTranslationAttemptRequest.class, request);
+
+        var sourceToTargetTranslationRequest = (SourceToTargetTranslationAttemptRequest) request;
+        assertEquals("123", sourceToTargetTranslationRequest.getQuestionID());
+        assertEquals("test answer", sourceToTargetTranslationRequest.getUserResponse());
+        assertEquals(QuestionType.SourceToTargetTranslation, sourceToTargetTranslationRequest.getQuestionType());
+    }
 }

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptRequests/SourceToTargetTranslationAttemptRequestTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptRequests/SourceToTargetTranslationAttemptRequestTest.java
@@ -1,0 +1,81 @@
+package com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class SourceToTargetTranslationAttemptRequestTest {
+    @Test
+    void shouldCreateRequest() {
+        var request = new SourceToTargetTranslationAttemptRequest("q123", "Jag heter David.");
+
+        assertEquals("q123", request.getQuestionID());
+        assertEquals("Jag heter David.", request.getUserResponse());
+        assertEquals(QuestionType.SourceToTargetTranslation, request.getQuestionType());
+    }
+
+    @Test
+    void shouldThrowExceptionForBlankQuestionId() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new SourceToTargetTranslationAttemptRequest("", "Jag heter David."));
+    }
+
+    @Test
+    void shouldNotThrowExceptionForBlankUserResponse() {
+        assertDoesNotThrow(() -> new SourceToTargetTranslationAttemptRequest("q123", ""));
+    }
+
+    @Test
+    void shouldCreateFromJsonNode() throws Exception {
+        var objectMapper = new ObjectMapper();
+        var json = """
+            {
+                "questionType": "SourceToTargetTranslation",
+                "questionID": "123",
+                "userResponse": "test answer"
+            }
+            """;
+        var node = objectMapper.readTree(json);
+        var request = AttemptRequest.fromJsonNode(node);
+
+        assertInstanceOf(SourceToTargetTranslationAttemptRequest.class, request);
+
+        var sourceToTargetTranslationRequest = (SourceToTargetTranslationAttemptRequest) request;
+        assertEquals("123", sourceToTargetTranslationRequest.getQuestionID());
+        assertEquals("test answer", sourceToTargetTranslationRequest.getUserResponse());
+        assertEquals(QuestionType.SourceToTargetTranslation, sourceToTargetTranslationRequest.getQuestionType());
+    }
+
+    @Test
+    void fromJsonNodeShouldThrowExceptionForMissingQuestionId() throws Exception {
+        var objectMapper = new ObjectMapper();
+        var json = """
+            {
+                "questionType": "SourceToTargetTranslation",
+                "userResponse": "test answer"
+            }
+            """;
+        var node = objectMapper.readTree(json);
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> AttemptRequest.fromJsonNode(node)
+        );
+    }
+
+    @Test
+    void fromJsonNodeShouldThrowExceptionForMissingUserResponse() throws Exception {
+        var objectMapper = new ObjectMapper();
+        var json = """
+            {
+                "questionType": "SourceToTargetTranslation",
+                "questionID": "123"
+            }
+            """;
+        var node = objectMapper.readTree(json);
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> AttemptRequest.fromJsonNode(node)
+        );
+    }
+}

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptResponses/SourceToTargetTranslationAttemptResponseTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Attempt/AttemptResponses/SourceToTargetTranslationAttemptResponseTest.java
@@ -1,0 +1,23 @@
+package com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses;
+
+import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
+import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class SourceToTargetTranslationAttemptResponseTest {
+    @Test
+    void shouldCreateResponse() {
+        var response = new SourceToTargetTranslationAttemptResponse(AttemptStatus.Success, "Jag heter David.");
+
+        assertEquals(AttemptStatus.Success, response.getAttemptStatus());
+        assertEquals(QuestionType.SourceToTargetTranslation, response.getQuestionType());
+        assertEquals("Jag heter David.", response.getCorrectAnswer());
+    }
+
+    @Test
+    void shouldThrowExceptionForBlankCorrectAnswer() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new SourceToTargetTranslationAttemptResponse(AttemptStatus.Success, ""));
+    }
+}

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/QuestionDTOTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/QuestionDTOTest.java
@@ -3,6 +3,7 @@ package com.munetmo.lingetic.LanguageTestService.DTOs.Question;
 import com.munetmo.lingetic.LanguageService.Entities.Language;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.FillInTheBlanksQuestion;
 import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
+import com.munetmo.lingetic.LanguageTestService.Entities.Questions.SourceToTargetTranslation;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -29,5 +30,24 @@ class QuestionDTOTest {
         assertEquals(QuestionType.FillInTheBlanks, dto.getQuestionType());
         assertEquals("Fill in: ___", ((FillInTheBlanksQuestionDTO) dto).getText());
         assertEquals("This is a hint", ((FillInTheBlanksQuestionDTO) dto).getHint());
+    }
+
+    @Test
+    void shouldConvertSourceToTargetTranslationQuestionToDTO() {
+        var question = new SourceToTargetTranslation(
+            "q123",
+            Language.English,
+            "Jag heter David.",
+            "I'm David.",
+            5,
+            TEST_QUESTION_LIST_ID
+        );
+
+        var dto = QuestionDTO.fromQuestion(question);
+
+        assertInstanceOf(SourceToTargetTranslationDTO.class, dto);
+        assertEquals("q123", dto.getID());
+        assertEquals(QuestionType.SourceToTargetTranslation, dto.getQuestionType());
+        assertEquals("I'm David.", ((SourceToTargetTranslationDTO) dto).getTranslation());
     }
 }

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/SourceToTargetTranslationDTOTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/DTOs/Question/SourceToTargetTranslationDTOTest.java
@@ -1,0 +1,39 @@
+package com.munetmo.lingetic.LanguageTestService.DTOs.Question;
+
+import com.munetmo.lingetic.LanguageService.Entities.Language;
+import com.munetmo.lingetic.LanguageTestService.Entities.Questions.QuestionType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SourceToTargetTranslationDTOTest {
+    @Test
+    void shouldCreateQuestionDTO() {
+        SourceToTargetTranslationDTO question = new SourceToTargetTranslationDTO(
+            "q123",
+            Language.Swedish,
+            "I'm David."
+        );
+
+        assertEquals("q123", question.getID());
+        assertEquals(QuestionType.SourceToTargetTranslation, question.getQuestionType());
+        assertEquals("I'm David.", question.getTranslation());
+        assertEquals(Language.Swedish, question.getLanguage());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenIdIsBlank() {
+        var exception = assertThrows(IllegalArgumentException.class, () -> new SourceToTargetTranslationDTO(
+            "", Language.Swedish, "I'm David."));
+        assertNotNull(exception.getMessage());
+        assertTrue(exception.getMessage().contains("id"));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenTranslationIsBlank() {
+        var exception = assertThrows(IllegalArgumentException.class, () -> new SourceToTargetTranslationDTO(
+            "q123", Language.Swedish, ""));
+        assertNotNull(exception.getMessage());
+        assertTrue(exception.getMessage().contains("translation"));
+    }
+}

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/QuestionTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/QuestionTest.java
@@ -1,0 +1,42 @@
+package com.munetmo.lingetic.LanguageTestService.Entities.Questions;
+
+import com.munetmo.lingetic.LanguageService.Entities.Language;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import java.util.Map;
+
+public class QuestionTest {
+    @Test
+    public void createFromQuestionTypeSpecificDataShouldCreateFillInTheBlanksQuestion() {
+        var id = "1";
+        var language = Language.English;
+        var difficulty = 1;
+        var questionListId = "list1";
+        Map<String, Object> data = Map.of(
+            "questionText", "Fill in the ___",
+            "answer", "blank"
+        );
+
+        var question = Question.createFromQuestionTypeSpecificData(id, language, difficulty, questionListId, QuestionType.FillInTheBlanks, data);
+
+        assertNotNull(question);
+        assertEquals(QuestionType.FillInTheBlanks, question.getQuestionType());
+    }
+
+    @Test
+    public void createFromQuestionTypeSpecificDataShouldCreateSourceToTargetTranslation() {
+        var id = "1";
+        var language = Language.English;
+        var difficulty = 1;
+        var questionListId = "list1";
+        Map<String, Object> data = Map.of(
+            "targetText", "Jag heter David.",
+            "translation", "I'm David."
+        );
+
+        var question = Question.createFromQuestionTypeSpecificData(id, language, difficulty, questionListId, QuestionType.SourceToTargetTranslation, data);
+
+        assertNotNull(question);
+        assertEquals(QuestionType.SourceToTargetTranslation, question.getQuestionType());
+    }
+}

--- a/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/SourceToTargetTranslationTest.java
+++ b/lingetic-spring-backend/src/test/java/com/munetmo/lingetic/LanguageTestService/Entities/Questions/SourceToTargetTranslationTest.java
@@ -1,0 +1,174 @@
+package com.munetmo.lingetic.LanguageTestService.Entities.Questions;
+
+import com.munetmo.lingetic.LanguageService.Entities.Language;
+import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests.FillInTheBlanksAttemptRequest;
+import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptRequests.SourceToTargetTranslationAttemptRequest;
+import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.FillInTheBlanksAttemptResponse;
+import com.munetmo.lingetic.LanguageTestService.DTOs.Attempt.AttemptResponses.SourceToTargetTranslationAttemptResponse;
+import com.munetmo.lingetic.LanguageTestService.Entities.AttemptStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SourceToTargetTranslationTest {
+    private final String defaultQuestionListId = "list-id";
+
+    @Test
+    void constructorShouldCreateValidObjectWithCorrectValues() {
+        var id = "test-id";
+        var language = Language.Swedish;
+        var targetText = "Jag heter David.";
+        var translation = "I'm David.";
+
+        SourceToTargetTranslation question = new SourceToTargetTranslation(id, language, targetText, translation, 5, defaultQuestionListId);
+
+        assertEquals(id, question.getID());
+        assertEquals(language, question.getLanguage());
+        assertEquals(QuestionType.SourceToTargetTranslation, question.getQuestionType());
+        assertEquals(targetText, question.targetText);
+        assertEquals(translation, question.translation);
+        assertEquals(5, question.difficulty);
+        assertEquals(defaultQuestionListId, question.getQuestionListID());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {" ", "   ", "\t", "\n"})
+    void constructorShouldThrowExceptionWhenIdIsInvalid(String id) {
+        assertThrows(IllegalArgumentException.class, () ->
+            new SourceToTargetTranslation(id, Language.Swedish, "Jag heter David.", "I'm David.", 5, defaultQuestionListId)
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {" ", "   ", "\t", "\n"})
+    void constructorShouldThrowExceptionWhenQuestionListIdIsInvalid(String questionListId) {
+        assertThrows(IllegalArgumentException.class, () ->
+            new SourceToTargetTranslation("id", Language.Swedish, "Jag heter David.", "I'm David.", 5, questionListId)
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "   ", "\t", "\n"})
+    void constructorShouldThrowExceptionWhenTargetTextIsInvalid(String targetText) {
+        assertThrows(IllegalArgumentException.class, () ->
+            new SourceToTargetTranslation("id", Language.Swedish, targetText, "I'm David.", 5, defaultQuestionListId)
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "   ", "\t", "\n"})
+    void constructorShouldThrowExceptionWhenTranslationIsInvalid(String translation) {
+        assertThrows(IllegalArgumentException.class, () ->
+            new SourceToTargetTranslation("id", Language.Swedish, "Jag heter David.", translation, 5, defaultQuestionListId)
+        );
+    }
+
+    @Test
+    void assessAttemptShouldReturnSuccessForCorrectAnswer() {
+        SourceToTargetTranslation question = new SourceToTargetTranslation(
+            "id", Language.Swedish, "Jag heter David.", "I'm David.", 5, defaultQuestionListId
+        );
+        var request = new SourceToTargetTranslationAttemptRequest(question.getID(), question.targetText);
+
+        var response = (SourceToTargetTranslationAttemptResponse) question.assessAttempt(request);
+
+        assertEquals(AttemptStatus.Success, response.getAttemptStatus());
+        assertEquals(question.targetText, response.getCorrectAnswer());
+    }
+
+    @Test
+    void assessAttemptShouldReturnFailureForIncorrectAnswer() {
+        SourceToTargetTranslation question = new SourceToTargetTranslation(
+            "id", Language.Swedish, "Jag heter David.", "I'm David.", 5, defaultQuestionListId
+        );
+        var request = new SourceToTargetTranslationAttemptRequest(question.getID(), "wrong answer");
+
+        var response = (SourceToTargetTranslationAttemptResponse) question.assessAttempt(request);
+
+        assertEquals(AttemptStatus.Failure, response.getAttemptStatus());
+        assertEquals(question.targetText, response.getCorrectAnswer());
+    }
+
+    @Test
+    void assessAttemptShouldThrowIfAttemptTypeDoesNotMatch() {
+        var question = new SourceToTargetTranslation(
+            "id", Language.Swedish, "Jag heter David.", "I'm David.", 5, defaultQuestionListId
+        );
+
+        var request = new FillInTheBlanksAttemptRequest(question.getID(), "wrong answer");
+
+        assertThrows(IllegalArgumentException.class, () -> question.assessAttempt(request));
+    }
+
+    @Test
+    void getQuestionTypeSpecificDataShouldReturnCorrectMap() {
+        var question = new SourceToTargetTranslation(
+            "test-id",
+            Language.Swedish,
+            "Jag heter David.",
+            "I'm David.",
+            5,
+            defaultQuestionListId
+        );
+
+        var data = question.getQuestionTypeSpecificData();
+
+        assertEquals("Jag heter David.", data.get("targetText"));
+        assertEquals("I'm David.", data.get("translation"));
+    }
+
+    @Test
+    void createFromQuestionTypeSpecificDataShouldCreateEquivalentQuestion() {
+        var originalQuestion = new SourceToTargetTranslation(
+            "test-id",
+            Language.Swedish,
+            "Jag heter David.",
+            "I'm David.",
+            5,
+            defaultQuestionListId
+        );
+
+        var data = originalQuestion.getQuestionTypeSpecificData();
+        var newQuestion = SourceToTargetTranslation.createFromQuestionTypeSpecificData(
+            originalQuestion.getID(),
+            originalQuestion.getLanguage(),
+            originalQuestion.getDifficulty(),
+            originalQuestion.getQuestionListID(),
+            data
+        );
+
+        assertEquals(originalQuestion.getID(), newQuestion.getID());
+        assertEquals(originalQuestion.getLanguage(), newQuestion.getLanguage());
+        assertEquals(originalQuestion.getDifficulty(), newQuestion.getDifficulty());
+        assertEquals(originalQuestion.getQuestionListID(), newQuestion.getQuestionListID());
+        assertEquals(originalQuestion.targetText, newQuestion.targetText);
+        assertEquals(originalQuestion.translation, newQuestion.translation);
+    }
+
+    @Test
+    void createFromQuestionTypeSpecificDataShouldThrowExceptionWhenTargetTextIsMissing() {
+        Map<String, Object> data = Map.of(
+            "translation", "I'm David."
+        );
+
+        assertThrows(IllegalArgumentException.class, () ->
+            SourceToTargetTranslation.createFromQuestionTypeSpecificData("id", Language.Swedish, 5, defaultQuestionListId, data)
+        );
+    }
+
+    @Test
+    void createFromQuestionTypeSpecificDataShouldThrowExceptionWhenTranslationIsMissing() {
+        Map<String, Object> data = Map.of(
+            "targetText", "Jag heter David."
+        );
+
+        assertThrows(IllegalArgumentException.class, () ->
+            SourceToTargetTranslation.createFromQuestionTypeSpecificData("id", Language.Swedish, 5, defaultQuestionListId, data)
+        );
+    }
+}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Added support for the SourceToTargetTranslation question type in the backend, including DTOs, entities, database migration, and tests.

- **New Features**
  - Implemented SourceToTargetTranslation question type with request and response handling.
  - Updated database schema and metadata to support the new type.
  - Added unit tests for new DTOs and entities.

<!-- End of auto-generated description by mrge. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new "Source to Target Translation" question type, allowing users to answer translation questions within the language test service.

- **Documentation**
  - Updated the contributing guide to include steps for supporting new question types, including frontend and API updates.

- **Bug Fixes**
  - Ensured database schema and backend logic support the new question type with proper validation and error handling.

- **Tests**
  - Added comprehensive tests for the new question type, including creation, validation, deserialization, and assessment logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->