### PR TITLE
Add loading screen between pages

### DIFF
--- a/lingetic-nextjs-frontend/app/languages/[language]/LearnPageComponent.tsx
+++ b/lingetic-nextjs-frontend/app/languages/[language]/LearnPageComponent.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter, useParams } from "next/navigation";
 import { ReactNode, useRef, useState } from "react";
-import { BookOpen, XCircle, Loader2 } from "lucide-react";
+import { BookOpen, XCircle } from "lucide-react";
 import useQuestions, { SuccessState } from "./useQuestions";
 import assert from "@/utilities/assert";
 import FillInTheBlanks from "@/app/components/questions/FillInTheBlanks/FillInTheBlanks";
@@ -15,6 +15,7 @@ import type {
 } from "@/utilities/api-types";
 import type QuestionProps from "@/app/components/questions/QuestionProps";
 import NextButton from "./NextButton";
+import { LoadingComponent } from "@/app/loading";
 
 export default function LearnPageComponent() {
   const params = useParams() as LearnPageParams;
@@ -43,14 +44,11 @@ export default function LearnPageComponent() {
 
   if (result.isLoading) {
     return (
-      <div className="h-full bg-gradient-to-b from-blue-50 to-white flex items-center justify-center">
-        <div className="bg-white p-8 rounded-xl shadow-lg max-w-md w-full text-center">
-          <Loader2 className="h-12 w-12 text-[#2563eb] animate-spin mx-auto mb-4" />
-          <p className="text-[#374151] text-lg">
-            Loading your language exercises...
-          </p>
-        </div>
-      </div>
+      <LoadingComponent>
+        <p className="text-[#374151] text-lg">
+          Loading your language exercises...
+        </p>
+      </LoadingComponent>
     );
   }
 

--- a/lingetic-nextjs-frontend/app/loading.tsx
+++ b/lingetic-nextjs-frontend/app/loading.tsx
@@ -1,0 +1,25 @@
+import { Loader2 } from "lucide-react";
+import { ReactNode } from "react";
+
+export default function LoadingPage() {
+  return (
+    <div className="flex-1">
+      <LoadingComponent />
+    </div>
+  );
+}
+
+interface LoadingComponentProps {
+  children?: ReactNode;
+}
+
+export function LoadingComponent({ children }: LoadingComponentProps) {
+  return (
+    <div className="h-full bg-gradient-to-b from-blue-50 to-white flex items-center justify-center">
+      <div className="bg-white p-8 rounded-xl shadow-lg max-w-md w-full text-center">
+        <Loader2 className="h-12 w-12 text-[#2563eb] animate-spin mx-auto mb-4" />
+        {children ?? <p className="text-[#374151] text-lg">Loading...</p>}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Added a loading screen that appears between page transitions to give users clear feedback while content loads.

- **New Features**
  - Created a reusable loading component with a spinner and message.
  - Updated the language learning page to use the new loading screen.

<!-- End of auto-generated description by mrge. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new, reusable loading indicator with improved styling and optional custom messages across the app.

- **Refactor**
  - Updated the language learning page to use the new loading component for a more consistent loading experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->