### PR TITLE
Disable audio autoplay

### DIFF
--- a/lingetic-nextjs-frontend/app/components/questions/FillInTheBlanks/ActionButton.tsx
+++ b/lingetic-nextjs-frontend/app/components/questions/FillInTheBlanks/ActionButton.tsx
@@ -22,7 +22,7 @@ export default function ActionButton({
 }: ActionButtonProps) {
   return (
     <div className="flex justify-end items-center gap-3">
-      <Speaker question={question} autoplay />
+      <Speaker question={question} autoplay={isChecked} />
       {isChecked ? (
         NextButton
       ) : (


### PR DESCRIPTION
Audio autoplay gives away the answer and makes
learning difficult.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Disabled audio autoplay in fill-in-the-blanks questions to prevent giving away answers and support better learning.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Audio playback in fill-in-the-blanks questions now only occurs when the related option is selected, preventing unwanted automatic playback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->