### PR TITLE
Drop the question_reviews table

### DIFF
--- a/lingetic-spring-backend/src/main/resources/db/migration/V17__Remove_Question_Reviews_Table.sql
+++ b/lingetic-spring-backend/src/main/resources/db/migration/V17__Remove_Question_Reviews_Table.sql
@@ -1,0 +1,2 @@
+-- Drop question_reviews table
+DROP TABLE IF EXISTS question_reviews;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed the question_reviews table from the database to clean up unused data structures.

<!-- End of auto-generated description by cubic. -->

