### PR TITLE
Show human readable language name

### DIFF
--- a/lingetic-nextjs-frontend/app/components/questions/Translation/MainComponent.tsx
+++ b/lingetic-nextjs-frontend/app/components/questions/Translation/MainComponent.tsx
@@ -7,6 +7,7 @@ import type {
     TranslationQuestionDTO,
 } from "@/utilities/api-types";
 import type { ChangeEvent, KeyboardEvent } from "react";
+import { languageIDToName } from "@/app/languages/constants";
 
 interface MainComponentProps {
     isChecked: boolean;
@@ -50,7 +51,7 @@ export default function MainComponent({
                 )}
             </div>
             <div className="text-sm text-gray-600">
-                Translate from {question.translateFromLanguage} to {question.translateToLanguage}
+                Translate to {languageIDToName[question.translateToLanguage]}.
             </div>
         </div>
     );

--- a/lingetic-nextjs-frontend/app/languages/constants.ts
+++ b/lingetic-nextjs-frontend/app/languages/constants.ts
@@ -52,13 +52,13 @@ export const languages: LanguageProperty[] = [
   // },
   {
     id: "JapaneseModifiedHepburn",
-    name: "Japanese 1",
+    name: "Japanese (Romanized)",
     image: "/img/languages/japanese-flag.png",
     isSupported: true,
   },
   // {
   //   id: "Japanese",
-  //   name: "Japanese 2",
+  //   name: "Japanese",
   //   image: "/img/languages/japanese-flag.png",
   //   isSupported: false,
   // },
@@ -101,3 +101,7 @@ export const languageNameToCode: Record<Language, string> = {
   Turkish: "tr",
   JapaneseModifiedHepburn: "ja-hepburn",
 };
+
+export const languageIDToName: Record<string, string> = Object.fromEntries(
+  languages.map((lang) => [lang.id, lang.name])
+);


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
• Update Japanese language display names for clarity
• Add language ID to name mapping utility
• Show human-readable language names in translation UI


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>constants.ts</strong><dd><code>Add language name mapping and update Japanese labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lingetic-nextjs-frontend/app/languages/constants.ts

• Updated Japanese language names from "Japanese 1/2" to "Japanese <br>(Romanized)" and "Japanese"<br> • Added <code>languageIDToName</code> mapping object to <br>convert language IDs to display names


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/326/files#diff-845a99291c7191095468e5d6e255cd87a00403691aafc0107c42b05ad352e53b">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MainComponent.tsx</strong><dd><code>Display human-readable language names in translation UI</code>&nbsp; &nbsp; </dd></summary>
<hr>

lingetic-nextjs-frontend/app/components/questions/Translation/MainComponent.tsx

• Imported <code>languageIDToName</code> mapping from constants<br> • Updated <br>translation instruction text to use human-readable language names


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Lingetic/pull/326/files#diff-17dfdbad929529794442d81c78b0b4f5d1cd1f8bba300fa289ab6bf73ff15d25">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>