### PR TITLE
refactor: standardize sentence models with language fields

### DIFF
--- a/scripts/scripts/__init__.py
+++ b/scripts/scripts/__init__.py
@@ -1,16 +1,18 @@
-from . import questions
-from . import select_questions
-from . import tts
-from . import upload_to_r2
-from . import explanations
-from . import insert_sentences_into_db
-from . import insert_questions_into_db
-from . import japanese_to_romaji
-from . import combine_sentences
-from . import enrich_sentences
-from . import local_s3_server
-from . import deduplicate_sentences
-from . import book2sentences
+from . import (
+    book2sentences,
+    combine_sentences,
+    deduplicate_sentences,
+    enrich_sentences,
+    explanations,
+    insert_questions_into_db,
+    insert_sentences_into_db,
+    japanese_to_romaji,
+    local_s3_server,
+    questions,
+    select_questions,
+    tts,
+    upload_to_r2,
+)
 
 __all__ = [
     "book2sentences",


### PR DESCRIPTION
Update book2sentences and package to use explicit source/
target language and improved typing for I/O.

- Sentence.text/translation with sourceText/translationText to
  make field names explicit and avoid ambiguity.
- Add SentenceWithLanguages and SentenceWithLanguagesList models that
  include sourceLanguage and targetLanguage.
- Change processing functions to return SentenceWithLanguages and
  convert Gemini responses into the new model via
  get_sentence_with_languages().
- Update write_sentences and final_output to accept and emit the new
  typed SentenceWithLanguagesList.
- Reformat scripts package imports into a grouped import block for
  readability.

These changes make the output schema explicit about which language is
the source and which is the translation, improving clarity and easing
consumption by downstream tools.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized sentence models with explicit source and target languages to make the schema clear and unambiguous. Processing and output now emit typed sentences with languages for easier use by downstream tools.

- **Refactors**
  - Renamed Sentence.text/translation to sourceText/translationText.
  - Added SentenceWithLanguages (+List) with sourceLanguage and targetLanguage; processing now returns this type via get_sentence_with_languages.
  - Updated write_sentences and final_output to accept and emit SentenceWithLanguagesList.

<sup>Written for commit 8614bf8a26f188ae9e7c5f4ffa2211cbb08a6f05. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

