### PR TITLE
feat(scripts): concurrency control, format and strings

### DIFF
--- a/scripts/scripts/book2sentences.py
+++ b/scripts/scripts/book2sentences.py
@@ -78,7 +78,7 @@ def extract_text_from_pdf(filepath: str) -> List[str]:
     reader = PdfReader(filepath)
     page_texts = []
     for page in reader.pages:
-        page_text = page.extract_text()
+        page_text = " ".join(page.extract_text().split())
         if page_text:
             page_texts.append(page_text)
     return page_texts


### PR DESCRIPTION
Refactor scripts to improve stability and when calling theLLM client and output.

- Move get_global_gemini_client import into explanations module to fix
  ordering and grouping of imports.
- Reformat function signatures and long lines for readability (wrap args
  and strings).
- Add asyncio.Semaphore (limit 5) to explanations and enrich_sentences to
  throttle concurrent LLM requests and avoid overwhelming the client or
  hitting rate limits.
- Update async task creation to pass the semaphore and use async with
  around per-entry LLM calls.
- Minor logging and JSON writing formatting improvements.

These changes prevent excessive concurrent requests, improve error
logging readability, and tidy code formatting.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Throttle concurrent LLM calls in explanations.py and enrich_sentences.py using an asyncio.Semaphore (limit 5) to prevent rate-limit errors and stabilize runs. Also clean up formatting and logging, and normalize PDF text to single spaces.

- **Refactors**
  - Add semaphore; wrap per-entry LLM calls; pass it to task creation.
  - Reformat long signatures and strings; tidy JSON and logs.
  - Collapse whitespace in PDF text in book2sentences.py.

- **Bug Fixes**
  - Move get_global_gemini_client import in explanations.py to fix import ordering.

<sup>Written for commit 9d01730605848aa1ed3bfa0c9664186b366d6e26. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #357 
- <kbd>&nbsp;1&nbsp;</kbd> #356 👈 
<!-- GitButler Footer Boundary Bottom -->

